### PR TITLE
fix(row1728): accessor->normalize is a local variables and forget ini…

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -1725,7 +1725,7 @@ static bool ParseAccessor(Accessor *accessor, std::string *err,
   accessor->count = static_cast<size_t>(count);
   accessor->bufferView = static_cast<int>(bufferView);
   accessor->byteOffset = static_cast<size_t>(byteOffset);
-
+  accessor->normalized = normalized;
   {
     int comp = static_cast<int>(componentType);
     if (comp >= TINYGLTF_COMPONENT_TYPE_BYTE &&


### PR DESCRIPTION
accessor->normalize is a local variable and forget initial it, so the value may be true or false. Besides, the value of parse glTF do not assign to normalize