### PR TITLE
Silence a MSVC warning about narrowing conversion

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -522,7 +522,7 @@ struct Accessor {
       if ((bufferViewObject.byteStride % componentSizeInBytes) != 0) {
         return -1;
       }
-      return bufferViewObject.byteStride;
+      return static_cast<int>(bufferViewObject.byteStride);
     }
 
     return 0;


### PR DESCRIPTION
Hello again with a minor code change proposal!

We actually want to convert a size_t value into an int value in this return statement.

Fix the annoying MSVC warning by actually casting the bytestride to an int (in the accessor bytestride computation code)

Signed-off-by: Arthur Brainville (Ybalrid) <ybalrid@ybalrid.info>
  