### PR TITLE
Allow custom image loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ if (!ret) {
 ## Compile options
 
 * `TINYGLTF_NOEXCEPTION` : Disable C++ exception in JSON parsing. You can use `-fno-exceptions` or by defining the symbol `JSON_NOEXCEPTION` and `TINYGLTF_NOEXCEPTION`  to fully remove C++ exception codes when compiling TinyGLTF.
+* `TINYGLTF_NO_STB_IMAGE` : Do not load images with stb_image. Instead use `TinyGLTF::SetImageLoader(LoadimageDataFunction LoadImageData, void *user_data)` to set a callback for loading images.
 
 ### Saving gltTF 2.0 model
 

--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -730,10 +730,12 @@ enum SectionCheck {
 ///
 typedef bool (*LoadImageDataFunction)(Image *, std::string *, int, int, const unsigned char *, int, void *);
 
+#ifndef TINYGLTF_NO_STB_IMAGE
 // Declaration of default image loader callback
 static bool LoadImageData(Image *image, std::string *err, int req_width,
                           int req_height, const unsigned char *bytes,
                           int size, void*);
+#endif
 
 class TinyGLTF {
  public:
@@ -869,7 +871,11 @@ class TinyGLTF {
 #endif
 
 #include "./json.hpp"
+
+#ifndef TINYGLTF_NO_STB_IMAGE
 #include "./stb_image.h"
+#endif
+
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif
@@ -1186,6 +1192,7 @@ void TinyGLTF::SetImageLoader(LoadImageDataFunction func, void *user_data) {
     load_image_user_data_ = user_data;
 }
 
+#ifndef TINYGLTF_NO_STB_IMAGE
 static bool LoadImageData(Image *image, std::string *err, int req_width,
                           int req_height, const unsigned char *bytes,
                           int size, void*) {
@@ -1242,6 +1249,7 @@ static bool LoadImageData(Image *image, std::string *err, int req_width,
 
   return true;
 }
+#endif
 
 static bool IsDataURI(const std::string &in) {
   std::string header = "data:application/octet-stream;base64,";

--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -1162,8 +1162,6 @@ static bool LoadExternalFile(std::vector<unsigned char> *out, std::string *err,
 static bool LoadImageData(Image *image, std::string *err, int req_width,
                           int req_height, const unsigned char *bytes,
                           int size) {
-  //std::cout << "size " << size << std::endl;
-
   int w, h, comp;
   // if image cannot be decoded, ignore parsing and keep it by its path
   // don't break in this case

--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -450,7 +450,7 @@ struct Image {
   std::vector<unsigned char> image;
   int bufferView;        // (required if no uri)
   std::string mimeType;  // (required if no uri) ["image/jpeg", "image/png", "image/bmp", "image/gif"]
-  std::string uri;       // (reqiored if no mimeType)
+  std::string uri;       // (required if no mimeType)
   Value extras;
 
   Image() { bufferView = -1; }

--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -1228,12 +1228,12 @@ static bool IsDataURI(const std::string &in) {
   if (in.find(header) == 0) {
     return true;
   }
-  
+
   header = "data:image/png;base64,";
   if (in.find(header) == 0) {
     return true;
   }
-  
+
   header = "data:image/bmp;base64,";
   if(in.find(header) == 0) {
     return true;
@@ -1274,7 +1274,7 @@ static bool DecodeDataURI(std::vector<unsigned char> *out,
       data = base64_decode(in.substr(header.size()));  // cut mime string.
     }
   }
-  
+
   if (data.empty()) {
     header = "data:image/bmp;base64,";
     if (in.find(header) == 0) {
@@ -2560,7 +2560,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, const char *str,
   // FIXME Maybe a better way to handle it than removing the code
 
   {
-    json::const_iterator it = v.find("scenes"); 
+    json::const_iterator it = v.find("scenes");
     if ((it != v.end()) && it.value().is_array()) {
       // OK
     } else if (check_sections & REQUIRE_SCENES) {
@@ -2572,7 +2572,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, const char *str,
   }
 
   {
-    json::const_iterator it = v.find("nodes"); 
+    json::const_iterator it = v.find("nodes");
     if ((it != v.end()) && it.value().is_array()) {
       // OK
     } else if (check_sections & REQUIRE_NODES) {
@@ -2584,7 +2584,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, const char *str,
   }
 
   {
-    json::const_iterator it = v.find("accessors"); 
+    json::const_iterator it = v.find("accessors");
     if ((it != v.end()) && it.value().is_array()) {
       // OK
     } else if (check_sections & REQUIRE_ACCESSORS) {
@@ -2596,7 +2596,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, const char *str,
   }
 
   {
-    json::const_iterator it = v.find("buffers"); 
+    json::const_iterator it = v.find("buffers");
     if ((it != v.end()) && it.value().is_array()) {
       // OK
     } else if (check_sections & REQUIRE_BUFFERS) {
@@ -2608,7 +2608,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, const char *str,
   }
 
   {
-    json::const_iterator it = v.find("bufferViews"); 
+    json::const_iterator it = v.find("bufferViews");
     if ((it != v.end()) && it.value().is_array()) {
       // OK
     } else if (check_sections & REQUIRE_BUFFER_VIEWS) {
@@ -2631,7 +2631,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, const char *str,
 
   // 1. Parse Asset
   {
-    json::const_iterator it = v.find("asset"); 
+    json::const_iterator it = v.find("asset");
     if ((it != v.end()) && it.value().is_object()) {
       const json &root = it.value();
 
@@ -2641,7 +2641,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, const char *str,
 
   // 2. Parse extensionUsed
   {
-    json::const_iterator it = v.find("extensionsUsed"); 
+    json::const_iterator it = v.find("extensionsUsed");
     if ((it != v.end()) && it.value().is_array()) {
       const json &root = it.value();
       for (unsigned int i = 0; i < root.size(); ++i) {
@@ -2651,7 +2651,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, const char *str,
   }
 
   {
-    json::const_iterator it = v.find("extensionsRequired"); 
+    json::const_iterator it = v.find("extensionsRequired");
     if ((it != v.end()) && it.value().is_array()) {
       const json &root = it.value();
       for (unsigned int i = 0; i < root.size(); ++i) {
@@ -2662,7 +2662,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, const char *str,
 
   // 3. Parse Buffer
   {
-    json::const_iterator rootIt = v.find("buffers"); 
+    json::const_iterator rootIt = v.find("buffers");
     if ((rootIt != v.end()) && rootIt.value().is_array()) {
       const json &root = rootIt.value();
 
@@ -2685,10 +2685,10 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, const char *str,
       }
     }
   }
-  
+
   // 4. Parse BufferView
   {
-    json::const_iterator rootIt = v.find("bufferViews"); 
+    json::const_iterator rootIt = v.find("bufferViews");
     if ((rootIt != v.end()) && rootIt.value().is_array()) {
       const json &root = rootIt.value();
 
@@ -2713,7 +2713,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, const char *str,
 
   // 5. Parse Accessor
   {
-    json::const_iterator rootIt = v.find("accessors"); 
+    json::const_iterator rootIt = v.find("accessors");
     if ((rootIt != v.end()) && rootIt.value().is_array()) {
       const json &root = rootIt.value();
 
@@ -2738,7 +2738,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, const char *str,
 
   // 6. Parse Mesh
   {
-    json::const_iterator rootIt = v.find("meshes"); 
+    json::const_iterator rootIt = v.find("meshes");
     if ((rootIt != v.end()) && rootIt.value().is_array()) {
       const json &root = rootIt.value();
 
@@ -2763,7 +2763,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, const char *str,
 
   // 7. Parse Node
   {
-    json::const_iterator rootIt = v.find("nodes"); 
+    json::const_iterator rootIt = v.find("nodes");
     if ((rootIt != v.end()) && rootIt.value().is_array()) {
       const json &root = rootIt.value();
 
@@ -2788,7 +2788,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, const char *str,
 
   // 8. Parse scenes.
   {
-    json::const_iterator rootIt = v.find("scenes"); 
+    json::const_iterator rootIt = v.find("scenes");
     if ((rootIt != v.end()) && rootIt.value().is_array()) {
       const json &root = rootIt.value();
 
@@ -2823,7 +2823,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, const char *str,
 
   // 9. Parse default scenes.
   {
-    json::const_iterator rootIt = v.find("scene"); 
+    json::const_iterator rootIt = v.find("scene");
     if ((rootIt != v.end()) && rootIt.value().is_number_integer()) {
       const int defaultScene = rootIt.value();
 
@@ -2833,7 +2833,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, const char *str,
 
   // 10. Parse Material
   {
-    json::const_iterator rootIt = v.find("materials"); 
+    json::const_iterator rootIt = v.find("materials");
     if ((rootIt != v.end()) && rootIt.value().is_array()) {
       const json &root = rootIt.value();
 
@@ -2862,7 +2862,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, const char *str,
 
   // 11. Parse Image
   {
-    json::const_iterator rootIt = v.find("images"); 
+    json::const_iterator rootIt = v.find("images");
     if ((rootIt != v.end()) && rootIt.value().is_array()) {
       const json &root = rootIt.value();
 
@@ -2912,7 +2912,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, const char *str,
 
   // 12. Parse Texture
   {
-    json::const_iterator rootIt = v.find("textures"); 
+    json::const_iterator rootIt = v.find("textures");
     if ((rootIt != v.end()) && rootIt.value().is_array()) {
       const json &root = rootIt.value();
 
@@ -2937,7 +2937,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, const char *str,
 
   // 13. Parse Animation
   {
-    json::const_iterator rootIt = v.find("animations"); 
+    json::const_iterator rootIt = v.find("animations");
     if ((rootIt != v.end()) && rootIt.value().is_array()) {
       const json &root = rootIt.value();
 
@@ -2962,7 +2962,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, const char *str,
 
   // 14. Parse Skin
   {
-    json::const_iterator rootIt = v.find("skins"); 
+    json::const_iterator rootIt = v.find("skins");
     if ((rootIt != v.end()) && rootIt.value().is_array()) {
       const json &root = rootIt.value();
 
@@ -2987,7 +2987,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, const char *str,
 
   // 15. Parse Sampler
   {
-    json::const_iterator rootIt = v.find("samplers"); 
+    json::const_iterator rootIt = v.find("samplers");
     if ((rootIt != v.end()) && rootIt.value().is_array()) {
       const json &root = rootIt.value();
 
@@ -3012,7 +3012,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, const char *str,
 
   // 16. Parse Camera
   {
-    json::const_iterator rootIt = v.find("cameras"); 
+    json::const_iterator rootIt = v.find("cameras");
     if ((rootIt != v.end()) && rootIt.value().is_array()) {
       const json &root = rootIt.value();
 
@@ -3037,7 +3037,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, const char *str,
 
   // 17. Parse Extensions
   {
-    json::const_iterator rootIt = v.find("extensions"); 
+    json::const_iterator rootIt = v.find("extensions");
     if ((rootIt != v.end()) && rootIt.value().is_object()) {
       const json &root = rootIt.value();
 
@@ -3283,7 +3283,7 @@ static void SerializeValue(const std::string &key, const Value &value,
     for (unsigned int i = 0; i < valueKeys.size(); ++i) {
       Value elementValue = value.Get(valueKeys[i]);
       if (elementValue.IsInt())
-        jsonValue[valueKeys[i]] = 
+        jsonValue[valueKeys[i]] =
             static_cast<double>(elementValue.Get<int>());
     }
 


### PR DESCRIPTION
Hi @syoyo !

Thank you for creating and maintaining tinygltf!

I have a use case where I would like to use my own image loading (e.g. to support more formats than stb_image) and added `TinyGLTF::SetImageLoader` to be able to specify a callback that will be called instead of `LoadImageData`, which uses stb_image.

I made sure that by default it behaves exactly as before (I used my own tests for that, because I was unsure how to run your test suite), the custom image loader callback is entirely optional. In addition there is now a `TINYGLTF_NO_STB_IMAGE` compile flag which, if defined, will prevent inclusion on stb_image and remove the default image loader callback (therefore removing the dependency on it).

I recommend checking out the diffs of the last two commits independently, as the other three minor cleanup commits create a bit of noise in the diff.

Thanks in advance and keep up the awesome work.
Cheers, Jonathan.