### PR TITLE
Allow opting out of external image loading

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -1670,7 +1670,12 @@ static bool ParseImage(Image *image, std::string *err,
     if (IsDataURI(uri)) {
       loaded = DecodeDataURI(&img, uri, 0, false);
     } else {
-      // Assume external .bin file.
+      // Assume external file
+      // Keep texture path (for textures that cannot be decoded)
+      image->uri = uri;
+#ifdef TINYGLTF_NO_EXTERNAL_IMAGE
+      return true;
+#endif
       loaded = LoadExternalFile(&img, err, uri, basedir, 0, false);
     }
 
@@ -1717,10 +1722,11 @@ static bool ParseImage(Image *image, std::string *err,
       }
     } else {
       // Assume external file
-
       // Keep texture path (for textures that cannot be decoded)
       image->uri = uri;
-
+#ifdef TINYGLTF_NO_EXTERNAL_IMAGE
+      return true;
+#endif
       if (!LoadExternalFile(&img, err, uri, basedir, 0, false)) {
         if (err) {
           (*err) += "Failed to load external 'uri' for image parameter\n";


### PR DESCRIPTION
We do not require image loading for external files, we have separate texture directories at the moment.

I've also added saving the image->uri when loading a binary gltf. I assumed this was a mistake as well.