### PR TITLE
Fix MSVC build: removing static keyowrd befor tinygltf::LoadImageData

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -732,9 +732,9 @@ typedef bool (*LoadImageDataFunction)(Image *, std::string *, int, int,
 
 #ifndef TINYGLTF_NO_STB_IMAGE
 // Declaration of default image loader callback
-static bool LoadImageData(Image *image, std::string *err, int req_width,
-                          int req_height, const unsigned char *bytes, int size,
-                          void *);
+bool LoadImageData(Image *image, std::string *err, int req_width,
+                   int req_height, const unsigned char *bytes, int size,
+                   void *);
 #endif
 
 class TinyGLTF {
@@ -1197,9 +1197,9 @@ void TinyGLTF::SetImageLoader(LoadImageDataFunction func, void *user_data) {
 }
 
 #ifndef TINYGLTF_NO_STB_IMAGE
-static bool LoadImageData(Image *image, std::string *err, int req_width,
-                          int req_height, const unsigned char *bytes, int size,
-                          void *) {
+bool LoadImageData(Image *image, std::string *err, int req_width,
+                   int req_height, const unsigned char *bytes, int size,
+                   void *) {
   int w, h, comp;
   // if image cannot be decoded, ignore parsing and keep it by its path
   // don't break in this case


### PR DESCRIPTION
This is peculiar:
It looks like MSVC doesn't want to build when multiple compilation units
(e.g. multiple .cc files) uses tiny_gltf and this funciton is static.

The only one file that will build without error is the one that defined
the `TINYGLTF_IMPLEMENTATION` macro.

Removing `static` here solves the issue...

Signed-off-by: Arthur Brainville (Ybalrid) <ybalrid@ybalrid.info>