### PR TITLE
Added embed buffers as an option in serializer

### DIFF
--- a/examples/saver/main.cc
+++ b/examples/saver/main.cc
@@ -17,6 +17,7 @@ int main(int argc, char *argv[])
   std::string err;
   std::string input_filename(argv[1]);
   std::string output_filename(argv[2]);
+  std::string embedded_filename = output_filename.substr(0, output_filename.size() - 5) + "-Embedded.gltf";
 
   // assume ascii glTF.
   bool ret = loader.LoadASCIIFromFile(&model, &err, input_filename.c_str());
@@ -27,6 +28,9 @@ int main(int argc, char *argv[])
     return EXIT_FAILURE;
   }
   loader.WriteGltfSceneToFile(&model, output_filename);
+
+  // embed buffers
+  loader.WriteGltfSceneToFile(&model, embedded_filename, true);
 
   return EXIT_SUCCESS;
 


### PR DESCRIPTION
### Summary
- Extended function WriteGltfSceneToFile with embedBuffers argument, default is **false**.
- Added function base64_encode from base64  lib.
- Saver example also outputs embedded gltf.
  
### Question
Did an unsafe cast from size_t to unsigned int to get rid of compiler warning (line 3392), do we want it this way? I didn't want to edit the original implementation of base64_encode.
