### PR TITLE
small bugfix, serializer skipped texture samplers refering to first index.

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -3910,7 +3910,7 @@ static void SerializeGltfSkin(Skin &skin, json &o) {
 }
 
 static void SerializeGltfTexture(Texture &texture, json &o) {
-  if (texture.sampler > 0) {
+  if (texture.sampler > -1) {
     SerializeNumberProperty("sampler", texture.sampler, o);
   }
   SerializeNumberProperty("source", texture.source, o);


### PR DESCRIPTION
Missed a bug in my code from yesterday.
texture.sampler is an index referring to the sampler array, Correct check is "> -1".