### PR TITLE
Added missing extras serialization for nodes

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -3880,6 +3880,10 @@ static void SerializeGltfNode(Node &node, json &o) {
     SerializeNumberProperty<int>("camera", node.camera, o);
   }
 
+  if (node.extras.Type() != NULL_TYPE)
+    SerializeValue("extras", node.extras, o);
+  }
+
   SerializeExtensionMap(node.extensions, o);
   SerializeStringProperty("name", node.name, o);
   SerializeNumberArrayProperty<int>("children", node.children, o);

--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -3880,7 +3880,7 @@ static void SerializeGltfNode(Node &node, json &o) {
     SerializeNumberProperty<int>("camera", node.camera, o);
   }
 
-  if (node.extras.Type() != NULL_TYPE)
+  if (node.extras.Type() != NULL_TYPE) {
     SerializeValue("extras", node.extras, o);
   }
 


### PR DESCRIPTION
Noticed that extras field was not serialized for nodes (and many other elements).
(The existing extras serialization for scene and asset seem to check for the existance of keys in the element, but according to the spec, extras can be any type, not only objects.)