### PR TITLE
parse extras on the root object

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -3334,6 +3334,9 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, const char *str,
     }
   }
 
+  // 19. Parse Extras
+  ParseExtrasProperty(&model->extras, v);
+
   return true;
 }
 


### PR DESCRIPTION
The root object has "extras" property, which should be parsed.