### PR TITLE
Import texture names as well

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -456,6 +456,8 @@ struct Image {
 };
 
 struct Texture {
+  std::string name;
+
   int sampler;
   int source;  // Required (not specified in the spec ?)
   Value extras;
@@ -2223,6 +2225,8 @@ static bool ParseTexture(Texture *texture, std::string *err, const json &o,
 
   ParseExtensionsProperty(&texture->extensions, err, o);
   ParseExtrasProperty(&texture->extras, o);
+
+  ParseStringProperty(&texture->name, err, o, "name", false);
 
   return true;
 }


### PR DESCRIPTION
Every other structure has it already, so it's probably just an overlook. Simply copied the parser line from other places. To be extra sure, I double checked the spec that textures really can have the `"name"` field as well.

Thank you! :+1: 