### PR TITLE
Don't try to expand file paths on Emscripten.

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -1486,7 +1486,7 @@ std::string ExpandFilePath(const std::string &filepath, void *) {
 #else
 
 #if defined(TARGET_OS_IPHONE) || defined(TARGET_IPHONE_SIMULATOR) || \
-    defined(__ANDROID__)
+    defined(__ANDROID__) || defined(__EMSCRIPTEN__)
   // no expansion
   std::string s = filepath;
 #else


### PR DESCRIPTION
Since the same is done on all mobile platforms already, I think it should not do any harm. Without this I was getting compilation/linker errors.