### PR TITLE
Properly fail also when external *.bin are missing from *.glb.

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -2260,8 +2260,10 @@ static bool ParseBuffer(Buffer *buffer, std::string *err, const json &o,
         }
       } else {
         // External .bin file.
-        LoadExternalFile(&buffer->data, err, /* warn */ nullptr, buffer->uri,
-                         basedir, bytes, true, fs);
+        if (!LoadExternalFile(&buffer->data, err, /* warn */ nullptr, buffer->uri,
+                              basedir, bytes, true, fs)) {
+          return false;
+        }
       }
     } else {
       // load data from (embedded) binary data


### PR DESCRIPTION
When `*.bin` files referenced from `*.gltf` files are not found, the loading fails (as it should), but for `*.glb` it silently passed. Fixed that to make the behavior consistent.