### PR TITLE
yet another serialization fix

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -4126,7 +4126,8 @@ static void SerializeExtensionMap(ExtensionMap &extensions, json &o) {
     json ret;
     if (ValueToJson(extIt->second, &ret)) {
       extMap[extIt->first] = ret;
-    } else {
+    }
+    if(ret.is_null()) {
       if (!(extIt->first.empty())) { // name should not be empty, but for sure 
         // create empty object so that an extension name is still included in json.
         extMap[extIt->first] = json({});


### PR DESCRIPTION
fix an issue introduced by my latest "fix"

when serializing an empty extension object, it serializes as type null 
thus, it deserializes as type null, causing it to be ignored when parsed

```C++
  if (!extIt.value().is_object()) continue; // type is not an object here, ignored
  if (!ParseJsonAsValue(&extensions[extIt.key()], extIt.value())) {
    if (!extIt.key().empty()) {
      // create empty object so that an extension object is still of type object
      extensions[extIt.key()] = Value{ Value::Object{} };
    }
  }
```