### PR TITLE
make lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,4 @@ all:
 	clang++  $(EXTRA_CXXFLAGS) -std=c++11 -g -O0 -o loader_example loader_example.cc
 
 lint:
-	./cpplint.py tiny_gltf_loader.h
+	deps/cpplint.py tiny_gltf.h

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ v2.0.0 release(22 Aug, 2018)!
   * [x] Binary glTF(GLB)
   * [x] PBR material description
 * Buffers
-  * [x] Parse BASE64 encoded embedded buffer fata(DataURI).
+  * [x] Parse BASE64 encoded embedded buffer data(DataURI).
   * [x] Load `.bin` file.
 * Image(Using stb_image)
-  * [x] Parse BASE64 encoded embedded image fata(DataURI).
+  * [x] Parse BASE64 encoded embedded image data(DataURI).
   * [x] Load external image file.
   * [x] PNG(8bit only)
   * [x] JPEG(8bit only)


### PR DESCRIPTION
deps/cpplint.py tiny_gltf.h
tiny_gltf.h:4791:  #endif line should be "#endif  // TINY_GLTF_H_"  [build/header_guard] [5]
tiny_gltf.h:198:  Is this a non-const reference? If so, make const or use a pointer: std::string &mime_type  [runtime/references] [2]
tiny_gltf.h:364:  Using deprecated casting style.  Use static_cast<int>(...) instead  [readability/casting] [4]
tiny_gltf.h:999:  Should have a space between // and comment  [whitespace/comments] [4]
tiny_gltf.h:1117:  Using deprecated casting style.  Use static_cast<int>(...) instead  [readability/casting] [4]
tiny_gltf.h:1139:  Using deprecated casting style.  Use static_cast<int>(...) instead  [readability/casting] [4]
tiny_gltf.h:1288:  Line contains only semicolon. If this should be an empty statement, use {} instead.  [whitespace/semicolon] [5]
tiny_gltf.h:1812:  Using deprecated casting style.  Use static_cast<int>(...) instead  [readability/casting] [4]
tiny_gltf.h:1872:  Is this a non-const reference? If so, make const or use a pointer: Image &image  [runtime/references] [2]
tiny_gltf.h:1872:  Is this a non-const reference? If so, make const or use a pointer: std::string &baseDir  [runtime/references] [2]
tiny_gltf.h:1940:  Is this a non-const reference? If so, make const or use a pointer: std::string &mime_type  [runtime/references] [2]
tiny_gltf.h:2351:  Tab found; better to use spaces  [whitespace/tab] [1]
tiny_gltf.h:2353:  Lines should be <= 80 characters long  [whitespace/line_length] [2]
tiny_gltf.h:2356:  Tab found; better to use spaces  [whitespace/tab] [1]
tiny_gltf.h:2875:  Using deprecated casting style.  Use static_cast<int>(...) instead  [readability/casting] [4]
tiny_gltf.h:3244:  Use operator ! instead of not  [readability/alt_tokens] [2]
tiny_gltf.h:3247:  Redundant blank line at the end of a code block should be deleted.  [whitespace/blank_line] [3]
tiny_gltf.h:3981:  Is this a non-const reference? If so, make const or use a pointer: json &obj  [runtime/references] [2]
tiny_gltf.h:3991:  Is this a non-const reference? If so, make const or use a pointer: json &obj  [runtime/references] [2]
tiny_gltf.h:4004:  Is this a non-const reference? If so, make const or use a pointer: json &obj  [runtime/references] [2]
tiny_gltf.h:4010:  Is this a non-const reference? If so, make const or use a pointer: json &obj  [runtime/references] [2]
tiny_gltf.h:4038:  Using deprecated casting style.  Use static_cast<int>(...) instead  [readability/casting] [4]
tiny_gltf.h:4040:  Using deprecated casting style.  Use static_cast<int>(...) instead  [readability/casting] [4]
tiny_gltf.h:4046:  Missing username in TODO; it should look like "// TODO(my_username): Stuff."  [readability/todo] [2]
tiny_gltf.h:4067:  Is this a non-const reference? If so, make const or use a pointer: json &obj  [runtime/references] [2]
tiny_gltf.h:4073:  Is this a non-const reference? If so, make const or use a pointer: json &o  [runtime/references] [2]
tiny_gltf.h:4088:  Is this a non-const reference? If so, make const or use a pointer: ParameterMap &param  [runtime/references] [2]
tiny_gltf.h:4088:  Is this a non-const reference? If so, make const or use a pointer: json &o  [runtime/references] [2]
tiny_gltf.h:4117:  Is this a non-const reference? If so, make const or use a pointer: ExtensionMap &extensions  [runtime/references] [2]
tiny_gltf.h:4117:  Is this a non-const reference? If so, make const or use a pointer: json &o  [runtime/references] [2]
tiny_gltf.h:4130:  Missing space before ( in if(  [whitespace/parens] [5]
tiny_gltf.h:4131:  Line ends in whitespace.  Consider deleting these extra spaces.  [whitespace/end_of_line] [4]
tiny_gltf.h:4131:  At least two spaces is best between code and comments  [whitespace/comments] [2]
tiny_gltf.h:4132:  Lines should be <= 80 characters long  [whitespace/line_length] [2]
tiny_gltf.h:4140:  Is this a non-const reference? If so, make const or use a pointer: Accessor &accessor  [runtime/references] [2]
tiny_gltf.h:4140:  Is this a non-const reference? If so, make const or use a pointer: json &o  [runtime/references] [2]
tiny_gltf.h:4144:  Using deprecated casting style.  Use static_cast<int>(...) instead  [readability/casting] [4]
tiny_gltf.h:4183:  Is this a non-const reference? If so, make const or use a pointer: AnimationChannel &channel  [runtime/references] [2]
tiny_gltf.h:4183:  Is this a non-const reference? If so, make const or use a pointer: json &o  [runtime/references] [2]
tiny_gltf.h:4196:  Is this a non-const reference? If so, make const or use a pointer: AnimationSampler &sampler  [runtime/references] [2]
tiny_gltf.h:4196:  Is this a non-const reference? If so, make const or use a pointer: json &o  [runtime/references] [2]
tiny_gltf.h:4206:  Is this a non-const reference? If so, make const or use a pointer: Animation &animation  [runtime/references] [2]
tiny_gltf.h:4206:  Is this a non-const reference? If so, make const or use a pointer: json &o  [runtime/references] [2]
tiny_gltf.h:4233:  Is this a non-const reference? If so, make const or use a pointer: Asset &asset  [runtime/references] [2]
tiny_gltf.h:4233:  Is this a non-const reference? If so, make const or use a pointer: json &o  [runtime/references] [2]
tiny_gltf.h:4249:  Is this a non-const reference? If so, make const or use a pointer: Buffer &buffer  [runtime/references] [2]
tiny_gltf.h:4249:  Is this a non-const reference? If so, make const or use a pointer: json &o  [runtime/references] [2]
tiny_gltf.h:4260:  Is this a non-const reference? If so, make const or use a pointer: Buffer &buffer  [runtime/references] [2]
tiny_gltf.h:4260:  Is this a non-const reference? If so, make const or use a pointer: json &o  [runtime/references] [2]
tiny_gltf.h:4274:  Is this a non-const reference? If so, make const or use a pointer: BufferView &bufferView  [runtime/references] [2]
tiny_gltf.h:4274:  Is this a non-const reference? If so, make const or use a pointer: json &o  [runtime/references] [2]
tiny_gltf.h:4300:  Is this a non-const reference? If so, make const or use a pointer: Image &image  [runtime/references] [2]
tiny_gltf.h:4300:  Is this a non-const reference? If so, make const or use a pointer: json &o  [runtime/references] [2]
tiny_gltf.h:4314:  Is this a non-const reference? If so, make const or use a pointer: Material &material  [runtime/references] [2]
tiny_gltf.h:4314:  Is this a non-const reference? If so, make const or use a pointer: json &o  [runtime/references] [2]
tiny_gltf.h:4335:  Is this a non-const reference? If so, make const or use a pointer: Mesh &mesh  [runtime/references] [2]
tiny_gltf.h:4335:  Is this a non-const reference? If so, make const or use a pointer: json &o  [runtime/references] [2]
tiny_gltf.h:4398:  Is this a non-const reference? If so, make const or use a pointer: Light &light  [runtime/references] [2]
tiny_gltf.h:4398:  Is this a non-const reference? If so, make const or use a pointer: json &o  [runtime/references] [2]
tiny_gltf.h:4404:  Is this a non-const reference? If so, make const or use a pointer: Node &node  [runtime/references] [2]
tiny_gltf.h:4404:  Is this a non-const reference? If so, make const or use a pointer: json &o  [runtime/references] [2]
tiny_gltf.h:4438:  Is this a non-const reference? If so, make const or use a pointer: Sampler &sampler  [runtime/references] [2]
tiny_gltf.h:4438:  Is this a non-const reference? If so, make const or use a pointer: json &o  [runtime/references] [2]
tiny_gltf.h:4450:  Is this a non-const reference? If so, make const or use a pointer: json &o  [runtime/references] [2]
tiny_gltf.h:4462:  Is this a non-const reference? If so, make const or use a pointer: json &o  [runtime/references] [2]
tiny_gltf.h:4478:  Is this a non-const reference? If so, make const or use a pointer: json &o  [runtime/references] [2]
tiny_gltf.h:4497:  Is this a non-const reference? If so, make const or use a pointer: Scene &scene  [runtime/references] [2]
tiny_gltf.h:4497:  Is this a non-const reference? If so, make const or use a pointer: json &o  [runtime/references] [2]
tiny_gltf.h:4509:  Is this a non-const reference? If so, make const or use a pointer: Skin &skin  [runtime/references] [2]
tiny_gltf.h:4509:  Is this a non-const reference? If so, make const or use a pointer: json &o  [runtime/references] [2]
tiny_gltf.h:4520:  Is this a non-const reference? If so, make const or use a pointer: Texture &texture  [runtime/references] [2]
tiny_gltf.h:4520:  Is this a non-const reference? If so, make const or use a pointer: json &o  [runtime/references] [2]
tiny_gltf.h:4577:  Lines should be <= 80 characters long  [whitespace/line_length] [2]
tiny_gltf.h:4597:  Line ends in whitespace.  Consider deleting these extra spaces.  [whitespace/end_of_line] [4]
tiny_gltf.h:4601:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
tiny_gltf.h:4601:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
tiny_gltf.h:4605:  Missing space before ( in while(  [whitespace/parens] [5]
tiny_gltf.h:4610:  Lines should be <= 80 characters long  [whitespace/line_length] [2]
tiny_gltf.h:4616:  Tab found; better to use spaces  [whitespace/tab] [1]
tiny_gltf.h:4651:  Using deprecated casting style.  Use static_cast<int>(...) instead  [readability/casting] [4]
tiny_gltf.h:2298:  Add #include <utility> for pair<>  [build/include_what_you_use] [4]
Done processing tiny_gltf.h
Total errors found: 81
make: *** [Makefile:9: lint] Error 1
