### PR TITLE
Fixed a reference error which cause an error when writing images to disk

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -4130,7 +4130,7 @@ static void SerializeExtensionMap(ExtensionMap &extensions, json &o) {
       extMap[extIt->first] = ret;
     }
     if(ret.is_null()) {
-      if (!(extIt->first.empty())) { // name should not be empty, but for sure 
+      if (!(extIt->first.empty())) { // name should not be empty, but for sure
         // create empty object so that an extension name is still included in json.
         extMap[extIt->first] = json({});
       }
@@ -4597,7 +4597,7 @@ bool TinyGLTF::WriteGltfSceneToFile(Model *model, const std::string &filename,
     } else {
       std::string binSavePath;
       std::string binUri;
-      if (!model->buffers[i].uri.empty() 
+      if (!model->buffers[i].uri.empty()
         && !IsDataURI(model->buffers[i].uri)) {
         binUri = model->buffers[i].uri;
       }
@@ -4654,7 +4654,7 @@ bool TinyGLTF::WriteGltfSceneToFile(Model *model, const std::string &filename,
       json image;
 
       UpdateImageObject(model->images[i], baseDir, int(i), embedImages,
-                        &this->WriteImageData, &this->write_image_user_data_);
+                        &this->WriteImageData, this->write_image_user_data_);
       SerializeGltfImage(model->images[i], image);
       images.push_back(image);
     }


### PR DESCRIPTION
A reference to the pointer **this->write_image_user_data_** have been passed to **UpdateImageObject()** instead of the actual pointer. 

Also removed trailing whitespaces from two lines.

## Before this PR,
**FsCallbacks** could not be used when serializing image (due to write_image_user_data_ wrongly beeing passed as reference). 

## After PR 
images can be serialized as separate files to disk using **FsCallbacks**.

