### PR TITLE
some serialization fixes

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -4815,7 +4815,7 @@ bool TinyGLTF::WriteGltfSceneToFile(Model *model, const std::string &filename,
   if (writeBinary) {
     WriteBinaryGltfFile(filename, output.dump());
   } else {
-    WriteGltfFile(filename, output.dump(prettyPrint ? 2 : 0));
+    WriteGltfFile(filename, output.dump(prettyPrint ? 2 : -1));
   }
 
   return true;

--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -455,7 +455,8 @@ struct Sampler {
 
   Sampler()
       : wrapS(TINYGLTF_TEXTURE_WRAP_REPEAT),
-        wrapT(TINYGLTF_TEXTURE_WRAP_REPEAT) {}
+        wrapT(TINYGLTF_TEXTURE_WRAP_REPEAT),
+        wrapR(TINYGLTF_TEXTURE_WRAP_REPEAT){}
   bool operator==(const Sampler &) const;
 };
 


### PR DESCRIPTION
- Fix pretty print to really not print pretty (it was printing pretty with indentation 0).
- Default value for `sampler.wrapR`, uninitialized value was causing the `operator==` to fail. It was serialized with an uninitialized value. I remember adding the serialization, but in fact, looking through the code, it never even seems to be deserialized... Merging error? Legacy?