### PR TITLE
Add CMake package for developer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,3 +20,9 @@ INSTALL ( FILES
   DESTINATION
   include
   )
+
+INSTALL ( FILES
+  cmake/glTFConfig.cmake
+  DESTINATION
+  cmake
+  )

--- a/cmake/glTFConfig.cmake
+++ b/cmake/glTFConfig.cmake
@@ -1,0 +1,17 @@
+# -*- cmake -*-
+# - Find glTF
+
+# glTF_INCLUDE_DIR      glTF's include directory
+
+
+FIND_PACKAGE ( PackageHandleStandardArgs )
+
+SET ( glTF_INCLUDE_DIR "${glTF_DIR}/../include" CACHE STRING "glTF include directory")
+
+FIND_FILE ( glTF_HEADER tiny_gltf.h PATHS ${glTF_INCLUDE_DIR} )
+
+IF (glTF_HEADER)
+  # MESSAGE ( STATUS "FOUND tiny_gltf.h, glTF_INCLUDE_DIR = ${glTF_INCLUDE_DIR}")
+ELSE ()
+  MESSAGE ( FATAL_ERROR "Unable to find tiny_gltf.h, glTF_INCLUDE_DIR = ${glTF_INCLUDE_DIR}")
+ENDIF ()


### PR DESCRIPTION
Added the glTFConfig.cmake file so that once
installed, it is easy for developers to find
all the path location for include purposes.