### PR TITLE
Fix incorrect index into bufferViews array

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -3488,7 +3488,8 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
     {
       if (primitive.indices > -1) // has indices from parsing step, must be Element Array Buffer
       {
-        model->bufferViews[primitive.indices].target = TINYGLTF_TARGET_ELEMENT_ARRAY_BUFFER;
+        model->bufferViews[model->accessors[primitive.indices].bufferView]
+            .target = TINYGLTF_TARGET_ELEMENT_ARRAY_BUFFER;
         // we could optionally check if acessors' bufferView type is Scalar, as it should be
       }
     }


### PR DESCRIPTION
From the spec: "When a primitive's `indices` property is defined, it references the accessor to use for index data"

In the spec `accesors.bufferView` is optional, but in tinygltf it's required, so I don't check for the empty case.

@viperscape can you check this still does what you wanted?