### PR TITLE
Fix GLFW3 handling on CentOS

### DIFF
--- a/examples/glview/CMakeLists.txt
+++ b/examples/glview/CMakeLists.txt
@@ -1,12 +1,17 @@
 cmake_minimum_required(VERSION 3.6)
 project(glview)
 
+set ( CMAKE_PREFIX_PATH cmake )
+
 find_package ( GLEW REQUIRED )
+find_package ( GLFW3 REQUIRED )
 find_package ( OpenGL REQUIRED )
 
-find_library(COCOA_LIBRARY Cocoa)
-find_library(COREVIDEO_LIBRARY CoreVideo)
-find_library(IOKIT_LIBRARY IOKit)
+if (apple)
+  find_library(COCOA_LIBRARY Cocoa)
+  find_library(COREVIDEO_LIBRARY CoreVideo)
+  find_library(IOKIT_LIBRARY IOKit)
+endif (apple)
 
 set(CMAKE_CXX_STANDARD 11)
 
@@ -15,7 +20,7 @@ include_directories(
   ../common
   # ${OPENGL_INCLUDE_DIR}
   ${GLEW_INCLUDE_DIR}
-  ${GLFW_INCLUDE_DIR}
+  ${GLFW3_INCLUDE_DIR}
   )
 
 add_executable(glview
@@ -25,7 +30,7 @@ add_executable(glview
 
 target_link_libraries ( glview
   ${GLEW_LIBRARY}
-  ${GLFW_LIBRARY}
+  ${GLFW3_glfw_LIBRARY}
   ${OPENGL_gl_LIBRARY}
   ${OPENGL_glu_LIBRARY}
   ${COCOA_LIBRARY}

--- a/examples/glview/cmake/GLFW3Config.cmake
+++ b/examples/glview/cmake/GLFW3Config.cmake
@@ -1,0 +1,71 @@
+#-*-cmake-*-
+#
+# yue.nicholas@gmail.com
+#
+# This auxiliary CMake file helps in find the glfw3 headers and libraries
+#
+# GLFW3_FOUND            set if glfw3 is found.
+# GLFW3_INCLUDE_DIR      glfw3's include directory
+# GLFW3_LIBRARY_DIR      glfw3's library directory
+# GLFW3_LIBRARIES        all glfw3 libraries
+
+FIND_PACKAGE (Threads)
+
+FIND_PACKAGE ( PackageHandleStandardArgs )
+
+FIND_PATH( GLFW3_LOCATION include/GLFW/glfw3.h
+  "$ENV{GLFW3_HOME}"
+)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS ( GLFW3
+  REQUIRED_VARS GLFW3_LOCATION
+  )
+
+IF (GLFW3_FOUND)
+  SET( GLFW3_INCLUDE_DIR "${GLFW3_LOCATION}/include" CACHE STRING "GLFW3 include path")
+  IF (GLFW3_USE_STATIC_LIBS)
+    FIND_LIBRARY ( GLFW3_glfw_LIBRARY  libglfw3.a  ${GLFW3_LOCATION}/lib
+	  )
+  ELSE (GLFW3_USE_STATIC_LIBS)
+	# On windows build, we need to look for glfw3
+	IF (WIN32)
+	  SET ( GLFW3_LIBRARY_NAME glfw3 )
+	ELSE ()
+	  SET ( GLFW3_LIBRARY_NAME glfw )
+	ENDIF()
+    FIND_LIBRARY ( GLFW3_glfw_LIBRARY ${GLFW3_LIBRARY_NAME} ${GLFW3_LOCATION}/lib
+	  )
+  ENDIF (GLFW3_USE_STATIC_LIBS)
+
+  IF (APPLE)
+	FIND_LIBRARY ( COCOA_LIBRARY Cocoa )
+	FIND_LIBRARY ( IOKIT_LIBRARY IOKit )
+	FIND_LIBRARY ( COREVIDEO_LIBRARY CoreVideo )
+  ELSEIF (UNIX AND NOT APPLE)
+	SET ( GLFW3_REQUIRED_X11_LIBRARIES
+	  X11
+      Xi
+      Xrandr
+      Xinerama
+      Xcursor
+      Xxf86vm
+	  m
+	  ${CMAKE_DL_LIBS}
+	  ${CMAKE_THREAD_LIBS_INIT}
+      )
+  ENDIF ()
+  
+  SET ( GLFW3_LIBRARIES
+	${OPENGL_gl_LIBRARY}
+	${OPENGL_glu_LIBRARY}
+	${GLFW3_glfw_LIBRARY}
+	# UNIX
+	${GLFW3_REQUIRED_X11_LIBRARIES}
+	# APPLE
+	${COCOA_LIBRARY}
+	${IOKIT_LIBRARY}
+	${COREVIDEO_LIBRARY}
+	CACHE STRING "GLFW3 required libraries"
+	)
+  
+ENDIF ()


### PR DESCRIPTION
Developers still need to specify the location of their GLFW3 installation via GLFW3_HOME environment variable when building via CMake
