### PR TITLE
Added new compiler option for loading all gltf related files from android app asset package

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ if (!ret) {
 * `TINYGLTF_NO_STB_IMAGE` : Do not load images with stb_image. Instead use `TinyGLTF::SetImageLoader(LoadimageDataFunction LoadImageData, void *user_data)` to set a callback for loading images.
 * `TINYGLTF_NO_STB_IMAGE_WRITE` : Do not write images with stb_image_write. Instead use `TinyGLTF::SetImageWriter(WriteimageDataFunction WriteImageData, void *user_data)` to set a callback for writing images.
 * `TINYGLTF_NO_EXTERNAL_IMAGE` : Do not try to load external image file. This option woulde be helpful if you do not want load image file during glTF parsing.
+* `TINYGLTF_ANDROID_LOAD_FROM_ASSETS`: Load all files from packaged app assets instead of the regular file system. **Note:** You must pass a valid asset manager from your android app to `tinygltf::asset_manager` beforehand.
 
 ### Saving gltTF 2.0 model
 * [ ] Buffers.


### PR DESCRIPTION
This PR adds the new compiler option `TINYGLTF_ANDROID_LOAD_FROM_ASSETS` that will load all files, including textures and binaries from the packaged apk instead of the file system using the asset manager.

With this you can package arbitrary gltf files with your Android apk and load them directly from your application package without having to use embedded gltf files.

With this change you can simply take any gltf model like the Polly sample scene, add the directory as an asset to your Android build and load it up like you'd be working with a plain directory.

Demo video: https://youtu.be/rFXgeuyI4H4

P.S.: I'm not 100% sure if the coding style fits your guidelines for this library, so if anything needs to be changed just drop me a line.

