### PR TITLE
fix ci build of example

### DIFF
--- a/examples/raytrace/img-loaders.cc
+++ b/examples/raytrace/img-loaders.cc
@@ -1,3 +1,5 @@
 
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"
+#define LODEPNG_IMPLEMENTATION
+#include "lodepng.h"

--- a/examples/raytrace/premake5.lua
+++ b/examples/raytrace/premake5.lua
@@ -9,7 +9,7 @@ newoption {
 }
 
 sources = {
-   "stbi-impl.cc",
+   "img-loaders.cc",
    "main.cc",
    "render.cc",
    "render-config.cc",


### PR DESCRIPTION
one of the programs built by the CI scripts wasn't declaring the single-header implementation of lodepng, making the CI build fail for no good reason.

liked to issue #132 