### PR TITLE
Initial support for draco mesh compression

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -1078,10 +1078,6 @@ class TinyGLTF {
 #include "stb_image_write.h"
 #endif
 
-#ifdef TINYGLTF_USE_DRACO
-#include "draco/compression/decode.h"
-#endif // TINYGLTF_USE_DRACO
-
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif


### PR DESCRIPTION
Initial support for draco mesh compression. In this PR, we establish that draco is a dependency built external to tinygltf, which breaks from the current tradition of header only dependencies. For that reason, this feature is hidden behind a #define TINYGLTF_ENABLE_DRACO and requires developers to explicitly opt-in for draco support.

In this change, tinygltf any primitive using draco compression will:
If indices are specified
1) Decode the index buffer using draco, creating a new buffer and bufferview, adding to Model::bufferViews and Model::buffer collections
2) Update the primitive's accessor id to reference this new decoded bufferview.
For each attribute semantic specified by the draco extension
1) Decode the vertex buffer using draco, creating a new buffer and bufferview, adding to Model::bufferViews and Model::buffer collections
2) Update the primitive's accessor id to reference this new decoded bufferview.

TODO:

- [ ] Update README.
- [ ] Provide unit tests or examples.
- [ ] Consider adding draco as a submodule and update cmake build to build draco