### PR TITLE
Fix glView in case there is no default scene

### DIFF
--- a/examples/glview/glview.cc
+++ b/examples/glview/glview.cc
@@ -783,7 +783,7 @@ int main(int argc, char **argv) {
   Init();
 
   // DBG
-  PrintNodes(model.scenes[model.defaultScene]);
+  PrintNodes(model.scenes[model.defaultScene > -1 ? model.defaultScene : 0]);
 
   if (!glfwInit()) {
     std::cerr << "Failed to initialize GLFW." << std::endl;

--- a/examples/glview/glview.cc
+++ b/examples/glview/glview.cc
@@ -701,10 +701,11 @@ static void DrawModel(tinygltf::Model &model) {
     DrawCurves(scene, it->second);
   }
 #else
-
-  // TODO(syoyo): Support non-default scenes.
-  assert(model.defaultScene >= 0);
-  const tinygltf::Scene &scene = model.scenes[model.defaultScene];
+  //If the glTF asset has at least one scene, and doesn't define a default one
+  //just show the first one we can find
+  assert(model.scenes.size() > 0);
+  int scene_to_display = model.defaultScene > -1 ? model.defaultScene : 0;
+  const tinygltf::Scene &scene = model.scenes[scene_to_display];
   for (size_t i = 0; i < scene.nodes.size(); i++) {
     DrawNode(model, model.nodes[scene.nodes[i]]);
   }


### PR DESCRIPTION
Hi, 

Here's a tiny patch that fixes glvew in case a gltf asset doesn't have a default scene.

For context, because I think you'll find this interesting : while I was playing around with the idea of using tinygltf ot load [VRM avatars](https://dwango.github.io/vrm/), I was firstly trying to just display their content as a regular .glb file using the glview example.

(These are basically just glTF 2.0 assets distributed in binary form, with extra metadata as extensions in the JSON parts of the file. They are intended to be used with virtual reality social applications.)

These files don't define a default scene, there's a few `todo` comments in  glview code regarding this. I modified it so that it used the first element of the `.scenes` vector in that case, if the scene vector is not empty, thus not crashing anymore.

(I had a previous comment about another problem, but it actually was fixed earlier in the master branch that I hadn't re-based yet, everything is working as expected
![2019-01-28-022851_1920x1080_scrot](https://user-images.githubusercontent.com/1816251/51809871-46d33480-229c-11e9-8451-2e5d59e9c56e.png)

)

