### PR TITLE
Change AnimationSampler::interpolation to a non-required field.

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -3263,13 +3263,8 @@ static bool ParseAnimation(Animation *animation, std::string *err,
           }
           return false;
         }
-        if (!ParseStringProperty(&sampler.interpolation, err, s,
-                                 "interpolation", true)) {
-          if (err) {
-            (*err) += "`interpolation` field is missing in animation.sampler\n";
-          }
-          return false;
-        }
+        ParseStringProperty(&sampler.interpolation, err, s, "interpolation",
+                            false);
         if (!ParseNumberProperty(&outputIndex, err, s, "output", true)) {
           if (err) {
             (*err) += "`output` field is missing in animation.sampler\n";


### PR DESCRIPTION
The spec states to default to LINEAR when this field is not present, so parsing should not fail because a sampler is missing the "interpolation" field.