### PR TITLE
Fix for when json and stb is aready used in project

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ if (!ret) {
 * `TINYGLTF_NO_EXTERNAL_IMAGE` : Do not try to load external image file. This option woulde be helpful if you do not want load image file during glTF parsing.
 * `TINYGLTF_ANDROID_LOAD_FROM_ASSETS`: Load all files from packaged app assets instead of the regular file system. **Note:** You must pass a valid asset manager from your android app to `tinygltf::asset_manager` beforehand.
 * `TINYGLTF_ENABLE_DRACO`: Enable Draco compression. User must provide include path and link correspnding libraries in your project file.
+* `TINYGLTF_BYPASS_INCLUDE_JSON `: Disable including `json.hpp` from within `tiny_gltf.h` (usually because it has been included before).
+* `TINYGLTF_BYPASS_INCLUDE_STB_IMAGE `: Disable including `stb_image.h` from within `tiny_gltf.h` (usually because it has been included before).
+* `TINYGLTF_BYPASS_INCLUDE_STB_IMAGE_WRITE `: Disable including `stb_image_write.h` from within `tiny_gltf.h` (usually because it has been included before).
+
 
 ### Saving gltTF 2.0 model
 * [ ] Buffers.

--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ if (!ret) {
 * `TINYGLTF_NO_EXTERNAL_IMAGE` : Do not try to load external image file. This option woulde be helpful if you do not want load image file during glTF parsing.
 * `TINYGLTF_ANDROID_LOAD_FROM_ASSETS`: Load all files from packaged app assets instead of the regular file system. **Note:** You must pass a valid asset manager from your android app to `tinygltf::asset_manager` beforehand.
 * `TINYGLTF_ENABLE_DRACO`: Enable Draco compression. User must provide include path and link correspnding libraries in your project file.
-* `TINYGLTF_BYPASS_INCLUDE_JSON `: Disable including `json.hpp` from within `tiny_gltf.h` (usually because it has been included before).
-* `TINYGLTF_BYPASS_INCLUDE_STB_IMAGE `: Disable including `stb_image.h` from within `tiny_gltf.h` (usually because it has been included before).
-* `TINYGLTF_BYPASS_INCLUDE_STB_IMAGE_WRITE `: Disable including `stb_image_write.h` from within `tiny_gltf.h` (usually because it has been included before).
+* `TINYGLTF_BYPASS_INCLUDE_JSON `: Disable including `json.hpp` from within `tiny_gltf.h` because it has been already included before or you want to include it using custom path before including `tiny_gltf.h`.
+* `TINYGLTF_BYPASS_INCLUDE_STB_IMAGE `: Disable including `stb_image.h` from within `tiny_gltf.h` because it has been already included before or you want to include it using custom path before including `tiny_gltf.h`.
+* `TINYGLTF_BYPASS_INCLUDE_STB_IMAGE_WRITE `: Disable including `stb_image_write.h` from within `tiny_gltf.h` because it has been already included before or you want to include it using custom path before including `tiny_gltf.h`.
 
 
 ### Saving gltTF 2.0 model

--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ if (!ret) {
 * `TINYGLTF_NO_EXTERNAL_IMAGE` : Do not try to load external image file. This option woulde be helpful if you do not want load image file during glTF parsing.
 * `TINYGLTF_ANDROID_LOAD_FROM_ASSETS`: Load all files from packaged app assets instead of the regular file system. **Note:** You must pass a valid asset manager from your android app to `tinygltf::asset_manager` beforehand.
 * `TINYGLTF_ENABLE_DRACO`: Enable Draco compression. User must provide include path and link correspnding libraries in your project file.
-* `TINYGLTF_BYPASS_INCLUDE_JSON `: Disable including `json.hpp` from within `tiny_gltf.h` because it has been already included before or you want to include it using custom path before including `tiny_gltf.h`.
-* `TINYGLTF_BYPASS_INCLUDE_STB_IMAGE `: Disable including `stb_image.h` from within `tiny_gltf.h` because it has been already included before or you want to include it using custom path before including `tiny_gltf.h`.
-* `TINYGLTF_BYPASS_INCLUDE_STB_IMAGE_WRITE `: Disable including `stb_image_write.h` from within `tiny_gltf.h` because it has been already included before or you want to include it using custom path before including `tiny_gltf.h`.
+* `TINYGLTF_NO_INCLUDE_JSON `: Disable including `json.hpp` from within `tiny_gltf.h` because it has been already included before or you want to include it using custom path before including `tiny_gltf.h`.
+* `TINYGLTF_NO_INCLUDE_STB_IMAGE `: Disable including `stb_image.h` from within `tiny_gltf.h` because it has been already included before or you want to include it using custom path before including `tiny_gltf.h`.
+* `TINYGLTF_NO_INCLUDE_STB_IMAGE_WRITE `: Disable including `stb_image_write.h` from within `tiny_gltf.h` because it has been already included before or you want to include it using custom path before including `tiny_gltf.h`.
 
 
 ### Saving gltTF 2.0 model

--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -1077,7 +1077,7 @@ class TinyGLTF {
 #endif
 #endif
 
-#ifndef TINYGLTF_BYPASS_INCLUDE_JSON
+#ifndef TINYGLTF_NO_INCLUDE_JSON
 #include "json.hpp"
 #endif
 
@@ -1087,13 +1087,13 @@ class TinyGLTF {
 #endif
 
 #ifndef TINYGLTF_NO_STB_IMAGE
-#ifndef TINYGLTF_BYPASS_INCLUDE_STB_IMAGE
+#ifndef TINYGLTF_NO_INCLUDE_STB_IMAGE
 #include "stb_image.h"
 #endif
 #endif
 
 #ifndef TINYGLTF_NO_STB_IMAGE_WRITE
-#ifndef TINYGLTF_BYPASS_INCLUDE_STB_IMAGE
+#ifndef TINYGLTF_NO_INCLUDE_STB_IMAGE_WRITE
 #include "stb_image_write.h"
 #endif
 #endif

--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -1087,18 +1087,14 @@ class TinyGLTF {
 #endif
 
 #ifndef TINYGLTF_NO_STB_IMAGE
-#ifndef STB_IMAGE_IMPLEMENTATION
 #ifndef TINYGLTF_BYPASS_INCLUDE_STB_IMAGE
 #include "stb_image.h"
 #endif
 #endif
-#endif
 
 #ifndef TINYGLTF_NO_STB_IMAGE_WRITE
-#ifndef STB_IMAGE_WRITE_IMPLEMENTATION
 #ifndef TINYGLTF_BYPASS_INCLUDE_STB_IMAGE
 #include "stb_image_write.h"
-#endif
 #endif
 #endif
 

--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -1077,7 +1077,9 @@ class TinyGLTF {
 #endif
 #endif
 
+#ifndef TINYGLTF_BYPASS_INCLUDE_JSON
 #include "json.hpp"
+#endif
 
 #ifdef TINYGLTF_ENABLE_DRACO
 #include "draco/core/decoder_buffer.h"
@@ -1085,11 +1087,19 @@ class TinyGLTF {
 #endif
 
 #ifndef TINYGLTF_NO_STB_IMAGE
+#ifndef STB_IMAGE_IMPLEMENTATION
+#ifndef TINYGLTF_BYPASS_INCLUDE_STB_IMAGE
 #include "stb_image.h"
+#endif
+#endif
 #endif
 
 #ifndef TINYGLTF_NO_STB_IMAGE_WRITE
+#ifndef STB_IMAGE_WRITE_IMPLEMENTATION
+#ifndef TINYGLTF_BYPASS_INCLUDE_STB_IMAGE
 #include "stb_image_write.h"
+#endif
+#endif
 #endif
 
 #ifdef __clang__


### PR DESCRIPTION
The original code is as follows


```c++
#include "json.hpp"

#ifdef TINYGLTF_ENABLE_DRACO
#include "draco/core/decoder_buffer.h"
#include "draco/compression/decode.h"
#endif

#ifndef TINYGLTF_NO_STB_IMAGE
#include "stb_image.h"
#endif

#ifndef TINYGLTF_NO_STB_IMAGE_WRITE
#include "stb_image_write.h"
#endif
```

First issue is that if project already uses _std_ image stuff, compiler will throw _stb_ related redefinition errors when including _tinygltf_.

Second issue is also related to the fact that _json_ and _stb_ is used, however not by relative paths, but by using header search paths totally elsewher in file system. First issue could be resolved by refactoring project code, but this is a bit different. For example my code has

```c++
#define STB_IMAGE_IMPLEMENTATION
#define STB_IMAGE_WRITE_IMPLEMENTATION
#include <stb/stb_image.h>
#include <stb/stb_image_write.h>
#include <json/json.hpp>
```

Now, obviously _tinygltf_ will fail as there is no header at `#include "header_name.ext"`.

It might not be the most elegant way, but it is very explicit, by introducing 

```c++
TINYGLTF_BYPASS_INCLUDE_JSON
TINYGLTF_BYPASS_INCLUDE_STB_IMAGE
TINYGLTF_BYPASS_INCLUDE_STB_IMAGE_WRITE
```

So now we get the final pull:

```c++
#ifndef TINYGLTF_BYPASS_INCLUDE_JSON
#include "json.hpp"
#endif

#ifdef TINYGLTF_ENABLE_DRACO
#include "draco/core/decoder_buffer.h"
#include "draco/compression/decode.h"
#endif

#ifndef TINYGLTF_NO_STB_IMAGE
#ifndef TINYGLTF_BYPASS_INCLUDE_STB_IMAGE
#include "stb_image.h"
#endif
#endif

#ifndef TINYGLTF_NO_STB_IMAGE_WRITE
#ifndef TINYGLTF_BYPASS_INCLUDE_STB_IMAGE
#include "stb_image_write.h"
#endif
#endif
```

And user code can look something like this

```c++
// In practive this is equivalent to
//
//#define TINYGLTF_IMPLEMENTATION
//#define STB_IMAGE_IMPLEMENTATION
//#define STB_IMAGE_WRITE_IMPLEMENTATION
//#include "tiny_gltf.h"
//
// But here I have the ability to specify paths to json and stb myself
//
#define TINYGLTF_IMPLEMENTATION
#define STB_IMAGE_IMPLEMENTATION
#define STB_IMAGE_WRITE_IMPLEMENTATION
#define TINYGLTF_BYPASS_INCLUDE_JSON
#define TINYGLTF_BYPASS_INCLUDE_STB_IMAGE
#define TINYGLTF_BYPASS_INCLUDE_STB_IMAGE_WRITE
#include <json/json.hpp>
#include <stb/stb_image.h>
#include <stb/stb_image_write.h>
#include <tinygltf/tiny_gltf.h>
```

Or in case where project already uses _stb_ and/or _json_ somewhere up in the tree no refactoring is needed 

```c++
#define STB_IMAGE_IMPLEMENTATION
#define STB_IMAGE_WRITE_IMPLEMENTATION
#include <stb/stb_image.h>
#include <stb/stb_image_write.h>
#include <json/json.hpp>

// ...

#define TINYGLTF_IMPLEMENTATION
#define TINYGLTF_BYPASS_INCLUDE_JSON
#define TINYGLTF_BYPASS_INCLUDE_STB_IMAGE
#define TINYGLTF_BYPASS_INCLUDE_STB_IMAGE_WRITE
#include <tinygltf/tiny_gltf.h>
```

By using these bypass flags _tinygltf_ can use _json_ and _stb_ without introducing clashes.
