### PR TITLE
Parse integers directly instead of casting doubles

### DIFF
--- a/models/BoundsChecking/integer-out-of-bounds.gltf
+++ b/models/BoundsChecking/integer-out-of-bounds.gltf
@@ -1,0 +1,67 @@
+{
+  "scenes": [
+    {
+      "nodes": [0]
+    }
+  ],
+  "nodes": [
+    {
+      "mesh": 0
+    }
+  ],
+  "meshes": [
+    {
+      "primitives": [
+        {
+          "attributes": {
+            "POSITION": 1
+          },
+          "indices": 0
+        }
+      ]
+    }
+  ],
+  "buffers": [
+    {
+      "uri": "simpleTriangle.bin",
+      "byteLength": 44
+    }
+  ],
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteOffset": 0,
+      "byteLength": 1e300,
+      "target": 34963
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 8,
+      "byteLength": 36,
+      "target": 34962
+    }
+  ],
+  "accessors": [
+    {
+      "bufferView": 0,
+      "byteOffset": 0,
+      "componentType": 5123,
+      "count": 3,
+      "type": "SCALAR",
+      "max": [2],
+      "min": [0]
+    },
+    {
+      "bufferView": 1,
+      "byteOffset": 0,
+      "componentType": 5126,
+      "count": 3,
+      "type": "VEC3",
+      "max": [1, 1, 0],
+      "min": [0, 0, 0]
+    }
+  ],
+  "asset": {
+    "version": "2.0"
+  }
+}

--- a/tests/tester.cc
+++ b/tests/tester.cc
@@ -37,7 +37,7 @@ TEST_CASE("datauri-in-glb", "[issue-79]") {
   if (!err.empty()) {
     std::cerr << err << std::endl;
   }
-    
+
   REQUIRE(true == ret);
 }
 
@@ -147,4 +147,135 @@ TEST_CASE("glb-invalid-length", "[bounds-checking]") {
                                       sizeof(glb_invalid_length));
   REQUIRE_THAT(err, Catch::Contains("Invalid glTF binary."));
   REQUIRE_FALSE(ret);
+}
+
+TEST_CASE("integer-out-of-bounds", "[bounds-checking]") {
+  tinygltf::Model model;
+  tinygltf::TinyGLTF ctx;
+  std::string err;
+  std::string warn;
+
+  // Loading is expected to fail, but not crash.
+  bool ret = ctx.LoadASCIIFromFile(
+      &model, &err, &warn,
+      "../models/BoundsChecking/integer-out-of-bounds.gltf");
+  REQUIRE_THAT(err, Catch::Contains("not a positive integer"));
+  REQUIRE_FALSE(ret);
+}
+
+TEST_CASE("parse-integer", "[bounds-checking]") {
+  SECTION("parses valid numbers") {
+    std::string err;
+    int result = 123;
+    CHECK(tinygltf::ParseIntegerProperty(&result, &err, {{"zero", 0}}, "zero",
+                                         true));
+    REQUIRE(err == "");
+    REQUIRE(result == 0);
+
+    CHECK(tinygltf::ParseIntegerProperty(&result, &err, {{"int", -1234}}, "int",
+                                         true));
+    REQUIRE(err == "");
+    REQUIRE(result == -1234);
+  }
+
+  SECTION("detects missing properties") {
+    std::string err;
+    int result = -1;
+    CHECK_FALSE(tinygltf::ParseIntegerProperty(&result, &err, {}, "int", true));
+    REQUIRE_THAT(err, Catch::Contains("'int' property is missing"));
+    REQUIRE(result == -1);
+  }
+
+  SECTION("handled missing but not required properties") {
+    std::string err;
+    int result = -1;
+    CHECK_FALSE(
+        tinygltf::ParseIntegerProperty(&result, &err, {}, "int", false));
+    REQUIRE(err == "");
+    REQUIRE(result == -1);
+  }
+
+  SECTION("invalid integers") {
+    std::string err;
+    int result = -1;
+
+    CHECK_FALSE(tinygltf::ParseIntegerProperty(&result, &err, {{"int", 0.5}},
+                                               "int", true));
+    REQUIRE_THAT(err, Catch::Contains("not an integer type"));
+
+    // Excessively large values and NaN aren't allowed either.
+    err.clear();
+    CHECK_FALSE(tinygltf::ParseIntegerProperty(&result, &err, {{"int", 1e300}},
+                                               "int", true));
+    REQUIRE_THAT(err, Catch::Contains("not an integer type"));
+
+    err.clear();
+    CHECK_FALSE(tinygltf::ParseIntegerProperty(
+        &result, &err, {{"int", std::numeric_limits<double>::quiet_NaN()}},
+        "int", true));
+    REQUIRE_THAT(err, Catch::Contains("not an integer type"));
+  }
+}
+
+TEST_CASE("parse-unsigned", "[bounds-checking]") {
+  SECTION("parses valid unsigned integers") {
+    // Use string-based parsing here, using the initializer list syntax doesn't
+    // parse 0 as unsigned.
+    json zero_obj = json::parse("{\"zero\": 0}");
+
+    std::string err;
+    size_t result = 123;
+    CHECK(
+        tinygltf::ParseUnsignedProperty(&result, &err, zero_obj, "zero", true));
+    REQUIRE(err == "");
+    REQUIRE(result == 0);
+  }
+
+  SECTION("invalid integers") {
+    std::string err;
+    size_t result = -1;
+
+    CHECK_FALSE(tinygltf::ParseUnsignedProperty(&result, &err, {{"int", -1234}},
+                                                "int", true));
+    REQUIRE_THAT(err, Catch::Contains("not a positive integer"));
+
+    err.clear();
+    CHECK_FALSE(tinygltf::ParseUnsignedProperty(&result, &err, {{"int", 0.5}},
+                                                "int", true));
+    REQUIRE_THAT(err, Catch::Contains("not a positive integer"));
+
+    // Excessively large values and NaN aren't allowed either.
+    err.clear();
+    CHECK_FALSE(tinygltf::ParseUnsignedProperty(&result, &err, {{"int", 1e300}},
+                                                "int", true));
+    REQUIRE_THAT(err, Catch::Contains("not a positive integer"));
+
+    err.clear();
+    CHECK_FALSE(tinygltf::ParseUnsignedProperty(
+        &result, &err, {{"int", std::numeric_limits<double>::quiet_NaN()}},
+        "int", true));
+    REQUIRE_THAT(err, Catch::Contains("not a positive integer"));
+  }
+}
+
+TEST_CASE("parse-integer-array", "[bounds-checking]") {
+  SECTION("parses valid integers") {
+    std::string err;
+    std::vector<int> result;
+    CHECK(tinygltf::ParseIntegerArrayProperty(&result, &err,
+                                              {{"x", {-1, 2, 3}}}, "x", true));
+    REQUIRE(err == "");
+    REQUIRE(result.size() == 3);
+    REQUIRE(result[0] == -1);
+    REQUIRE(result[1] == 2);
+    REQUIRE(result[2] == 3);
+  }
+
+  SECTION("invalid integers") {
+    std::string err;
+    std::vector<int> result;
+    CHECK_FALSE(tinygltf::ParseIntegerArrayProperty(
+        &result, &err, {{"x", {-1, 1e300, 3}}}, "x", true));
+    REQUIRE_THAT(err, Catch::Contains("not an integer type"));
+  }
 }


### PR DESCRIPTION
When parsing numeric values as doubles, its possible for users to
specify values that cannot be converted to integers, such as Inf, NaN,
and extremes such as 1e100.  If this value is received, and then cast to
an int, it is undefined behavior, which trips ubsan when running
tinygltf under a fuzzer.

Instead of parsing integral values as doubles, use nlohmann/json's
built-in support to parse integer and unsigned values directly, with
.is_number_integer() and .is_number_unsigned().

Add ParseIntegerProperty, ParseUnsignedProperty, and
ParseIntegerArrayProperty helpers that allow parsing directly to
int/uint values and update code to use them when appropriate.