### PR TITLE
Fix C4267 warning (size_t -> int) convertion

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -3094,7 +3094,7 @@ static bool ParseAccessor(Accessor *accessor, std::string *err, const json &o) {
     if (componentType >= TINYGLTF_COMPONENT_TYPE_BYTE &&
         componentType <= TINYGLTF_COMPONENT_TYPE_DOUBLE) {
       // OK
-      accessor->componentType = componentType;
+      accessor->componentType = int(componentType);
     } else {
       std::stringstream ss;
       ss << "Invalid `componentType` in accessor. Got " << componentType


### PR DESCRIPTION
Everthing's in the title.

With this tiny change, tinygltf builds 100% warning free on MSVC 2019.