### PR TITLE
Material names are stored once in material.name, then duplicated in "additionalValues"

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -3457,7 +3457,9 @@ static bool ParseMaterial(Material *material, std::string *err, const json &o) {
     } else {
       Parameter param;
       if (ParseParameterProperty(&param, err, o, it.key(), false)) {
-        material->additionalValues[it.key()] = param;
+        // names of materials have already been parsed. Putting it in this map
+        // doesn't correctly reflext the glTF specification
+        if (it.key() != "name") material->additionalValues[it.key()] = param;
       }
     }
   }


### PR DESCRIPTION
This patch prevent this duplication.

Without this patch, you have both Material.name being filled in by the caller function, and then this function insert "name" in the map that only should *only* contains the alpha blending and normal/occlusion/emissive values.