### PR TITLE
 Add Parameter::TextureStrength(). Precise default values. 

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -390,6 +390,7 @@ struct Parameter {
     if (it != std::end(json_double_value)) {
       return int(it->second);
     }
+    // As per the spec, if texCoord is ommited, this parameter is 0
     return 0;
   }
 
@@ -401,7 +402,20 @@ struct Parameter {
     if (it != std::end(json_double_value)) {
       return it->second;
     }
-    return -1;
+    // As per the spec, if scale is ommited, this paramter is 1
+    return 1;
+  }
+  
+  /// Return the strength of a texture if this Parameter is a an occlusion map.
+  /// Returned value is only valid if the parameter represent an occlusion map
+  /// from a material
+  double TextureStrength() const {
+    const auto it = json_double_value.find("strength");
+    if (it != std::end(json_double_value)) {
+      return it->second;
+    }
+    // As per the spec, if strenghth is ommited, this parameter is 1
+    return 1;
   }
 
   /// Material factor, like the roughness or metalness of a material

--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -405,7 +405,7 @@ struct Parameter {
     // As per the spec, if scale is ommited, this paramter is 1
     return 1;
   }
-  
+
   /// Return the strength of a texture if this Parameter is a an occlusion map.
   /// Returned value is only valid if the parameter represent an occlusion map
   /// from a material
@@ -462,7 +462,8 @@ struct AnimationChannel {
 struct AnimationSampler {
   int input;                  // required
   int output;                 // required
-  std::string interpolation;  // "LINEAR", "STEP","CUBICSPLINE" or user defined string. default "LINEAR"
+  std::string interpolation;  // "LINEAR", "STEP","CUBICSPLINE" or user defined
+                              // string. default "LINEAR"
   Value extras;
 
   AnimationSampler() : input(-1), output(-1), interpolation("LINEAR") {}


### PR DESCRIPTION
The default values on these methods as been set to what is described [here](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0?ts=4#normaltextureinfo) and [here](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0?ts=4#occlusiontextureinfo).

This is to keep consistent with the API behavior from #144

(also ran clang-format for good measure)