### PR TITLE
Serialize to stream

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -1023,6 +1023,12 @@ class TinyGLTF {
                             unsigned int check_sections = REQUIRE_VERSION);
 
   ///
+  /// Write glTF to stream, buffers and images will be embeded
+  ///
+  bool WriteGltfSceneToStream(Model *model, std::ostream &stream,
+                              bool prettyPrint, bool writeBinary);
+
+  ///
   /// Write glTF to file.
   ///
   bool WriteGltfSceneToFile(Model *model, const std::string &filename,
@@ -1054,6 +1060,7 @@ class TinyGLTF {
   bool LoadFromString(Model *model, std::string *err, std::string *warn,
                       const char *str, const unsigned int length,
                       const std::string &base_dir, unsigned int check_sections);
+
 
   const unsigned char *bin_data_;
   size_t bin_size_;
@@ -5257,52 +5264,10 @@ static void SerializeGltfTexture(Texture &texture, json &o) {
   SerializeExtensionMap(texture.extensions, o);
 }
 
-static bool WriteGltfFile(const std::string &output,
-                          const std::string &content) {
-  std::ofstream gltfFile(output.c_str());
-  if (!gltfFile.is_open()) return false;
-  gltfFile << content << std::endl;
-  return true;
-}
-
-static void WriteBinaryGltfFile(const std::string &output,
-                                const std::string &content) {
-  std::ofstream gltfFile(output.c_str(), std::ios::binary);
-
-  const std::string header = "glTF";
-  const int version = 2;
-  const int padding_size = content.size() % 4;
-
-  // 12 bytes for header, JSON content length, 8 bytes for JSON chunk info,
-  // padding
-  const int length = 12 + 8 + int(content.size()) + padding_size;
-
-  gltfFile.write(header.c_str(), header.size());
-  gltfFile.write(reinterpret_cast<const char *>(&version), sizeof(version));
-  gltfFile.write(reinterpret_cast<const char *>(&length), sizeof(length));
-
-  // JSON chunk info, then JSON data
-  const int model_length = int(content.size()) + padding_size;
-  const int model_format = 0x4E4F534A;
-  gltfFile.write(reinterpret_cast<const char *>(&model_length),
-                 sizeof(model_length));
-  gltfFile.write(reinterpret_cast<const char *>(&model_format),
-                 sizeof(model_format));
-  gltfFile.write(content.c_str(), content.size());
-
-  // Chunk must be multiplies of 4, so pad with spaces
-  if (padding_size > 0) {
-    const std::string padding = std::string(padding_size, ' ');
-    gltfFile.write(padding.c_str(), padding.size());
-  }
-}
-
-bool TinyGLTF::WriteGltfSceneToFile(Model *model, const std::string &filename,
-                                    bool embedImages = false,
-                                    bool embedBuffers = false,
-                                    bool prettyPrint = true,
-                                    bool writeBinary = false) {
-  json output;
+///
+/// Serialize all properties except buffers and images.
+///
+static void SerializeGltfModel(Model *model, json &o) {
 
   // ACCESSORS
   json accessors;
@@ -5311,7 +5276,7 @@ bool TinyGLTF::WriteGltfSceneToFile(Model *model, const std::string &filename,
     SerializeGltfAccessor(model->accessors[i], accessor);
     accessors.push_back(accessor);
   }
-  output["accessors"] = accessors;
+  o["accessors"] = accessors;
 
   // ANIMATIONS
   if (model->animations.size()) {
@@ -5323,14 +5288,259 @@ bool TinyGLTF::WriteGltfSceneToFile(Model *model, const std::string &filename,
         animations.push_back(animation);
       }
     }
-    output["animations"] = animations;
+    o["animations"] = animations;
   }
 
   // ASSET
   json asset;
   SerializeGltfAsset(model->asset, asset);
-  output["asset"] = asset;
+  o["asset"] = asset;
 
+
+  // BUFFERVIEWS
+  json bufferViews;
+  for (unsigned int i = 0; i < model->bufferViews.size(); ++i) {
+    json bufferView;
+    SerializeGltfBufferView(model->bufferViews[i], bufferView);
+    bufferViews.push_back(bufferView);
+  }
+  o["bufferViews"] = bufferViews;
+
+  // Extensions used
+  if (model->extensionsUsed.size()) {
+    SerializeStringArrayProperty("extensionsUsed", model->extensionsUsed,
+                                 o);
+  }
+
+  // Extensions required
+  if (model->extensionsRequired.size()) {
+    SerializeStringArrayProperty("extensionsRequired",
+                                 model->extensionsRequired, o);
+  }
+
+  // MATERIALS
+  if (model->materials.size()) {
+    json materials;
+    for (unsigned int i = 0; i < model->materials.size(); ++i) {
+      json material;
+      SerializeGltfMaterial(model->materials[i], material);
+      materials.push_back(material);
+    }
+    o["materials"] = materials;
+  }
+
+  // MESHES
+  if (model->meshes.size()) {
+    json meshes;
+    for (unsigned int i = 0; i < model->meshes.size(); ++i) {
+      json mesh;
+      SerializeGltfMesh(model->meshes[i], mesh);
+      meshes.push_back(mesh);
+    }
+    o["meshes"] = meshes;
+  }
+
+  // NODES
+  if (model->nodes.size()) {
+    json nodes;
+    for (unsigned int i = 0; i < model->nodes.size(); ++i) {
+      json node;
+      SerializeGltfNode(model->nodes[i], node);
+      nodes.push_back(node);
+    }
+    o["nodes"] = nodes;
+  }
+
+  // SCENE
+  if (model->defaultScene > -1) {
+    SerializeNumberProperty<int>("scene", model->defaultScene, o);
+  }
+
+  // SCENES
+  if (model->scenes.size()) {
+    json scenes;
+    for (unsigned int i = 0; i < model->scenes.size(); ++i) {
+      json currentScene;
+      SerializeGltfScene(model->scenes[i], currentScene);
+      scenes.push_back(currentScene);
+    }
+    o["scenes"] = scenes;
+  }
+
+  // SKINS
+  if (model->skins.size()) {
+    json skins;
+    for (unsigned int i = 0; i < model->skins.size(); ++i) {
+      json skin;
+      SerializeGltfSkin(model->skins[i], skin);
+      skins.push_back(skin);
+    }
+    o["skins"] = skins;
+  }
+
+  // TEXTURES
+  if (model->textures.size()) {
+    json textures;
+    for (unsigned int i = 0; i < model->textures.size(); ++i) {
+      json texture;
+      SerializeGltfTexture(model->textures[i], texture);
+      textures.push_back(texture);
+    }
+    o["textures"] = textures;
+  }
+
+  // SAMPLERS
+  if (model->samplers.size()) {
+    json samplers;
+    for (unsigned int i = 0; i < model->samplers.size(); ++i) {
+      json sampler;
+      SerializeGltfSampler(model->samplers[i], sampler);
+      samplers.push_back(sampler);
+    }
+    o["samplers"] = samplers;
+  }
+
+  // CAMERAS
+  if (model->cameras.size()) {
+    json cameras;
+    for (unsigned int i = 0; i < model->cameras.size(); ++i) {
+      json camera;
+      SerializeGltfCamera(model->cameras[i], camera);
+      cameras.push_back(camera);
+    }
+    o["cameras"] = cameras;
+  }
+
+  // EXTENSIONS
+  SerializeExtensionMap(model->extensions, o);
+
+  // LIGHTS as KHR_lights_cmn
+  if (model->lights.size()) {
+    json lights;
+    for (unsigned int i = 0; i < model->lights.size(); ++i) {
+      json light;
+      SerializeGltfLight(model->lights[i], light);
+      lights.push_back(light);
+    }
+    json khr_lights_cmn;
+    khr_lights_cmn["lights"] = lights;
+    json ext_j;
+
+    if (o.find("extensions") != o.end()) {
+      ext_j = o["extensions"];
+    }
+
+    ext_j["KHR_lights_punctual"] = khr_lights_cmn;
+
+    o["extensions"] = ext_j;
+  }
+
+  // EXTRAS
+  if (model->extras.Type() != NULL_TYPE) {
+    SerializeValue("extras", model->extras, o);
+  }
+}
+
+static bool WriteGltfStream(std::ostream &stream,
+                            const std::string &content) {
+  stream << content << std::endl;
+  return true;
+}
+
+static bool WriteGltfFile(const std::string &output,
+                          const std::string &content) {
+  std::ofstream gltfFile(output.c_str());
+  if (!gltfFile.is_open()) return false;
+  return WriteGltfStream(gltfFile, content);
+}
+
+static void WriteBinaryGltfStream(std::ostream &stream,
+                          const std::string &content) {
+
+  const std::string header = "glTF";
+  const int version = 2;
+  const int padding_size = content.size() % 4;
+
+  // 12 bytes for header, JSON content length, 8 bytes for JSON chunk info,
+  // padding
+  const int length = 12 + 8 + int(content.size()) + padding_size;
+
+  stream.write(header.c_str(), header.size());
+  stream.write(reinterpret_cast<const char *>(&version), sizeof(version));
+  stream.write(reinterpret_cast<const char *>(&length), sizeof(length));
+
+  // JSON chunk info, then JSON data
+  const int model_length = int(content.size()) + padding_size;
+  const int model_format = 0x4E4F534A;
+  stream.write(reinterpret_cast<const char *>(&model_length),
+                 sizeof(model_length));
+  stream.write(reinterpret_cast<const char *>(&model_format),
+                 sizeof(model_format));
+  stream.write(content.c_str(), content.size());
+
+  // Chunk must be multiplies of 4, so pad with spaces
+  if (padding_size > 0) {
+    const std::string padding = std::string(padding_size, ' ');
+    stream.write(padding.c_str(), padding.size());
+  }
+}
+
+static void WriteBinaryGltfFile(const std::string &output,
+                                const std::string &content) {
+  std::ofstream gltfFile(output.c_str(), std::ios::binary);
+  WriteBinaryGltfStream(gltfFile, content);
+}
+
+bool TinyGLTF::WriteGltfSceneToStream(Model *model, std::ostream &stream,
+                                    bool prettyPrint = true,
+                                    bool writeBinary = false) {
+  json output;
+
+  /// Serialize all properties except buffers and images.
+  SerializeGltfModel(model, output);
+
+  // BUFFERS
+  std::vector<std::string> usedUris;
+  json buffers;
+  for (unsigned int i = 0; i < model->buffers.size(); ++i) {
+    json buffer;
+    SerializeGltfBuffer(model->buffers[i], buffer);
+    buffers.push_back(buffer);
+  }
+  output["buffers"] = buffers;
+
+  // IMAGES
+  if (model->images.size()) {
+    json images;
+    for (unsigned int i = 0; i < model->images.size(); ++i) {
+      json image;
+
+      std::string dummystring = "";
+      // UpdateImageObject need baseDir but only uses it if embededImages is enable,
+      // since we won't write separte images when writing to a stream we use a dummystring
+      UpdateImageObject(model->images[i], dummystring, int(i), false,
+                        &this->WriteImageData, this->write_image_user_data_);
+      SerializeGltfImage(model->images[i], image);
+      images.push_back(image);
+    }
+    output["images"] = images;
+  }
+
+  if (writeBinary) {
+    WriteBinaryGltfStream(stream, output.dump());
+  } else {
+    WriteGltfStream(stream, output.dump(prettyPrint ? 2 : -1));
+  }
+
+  return true;
+}
+
+bool TinyGLTF::WriteGltfSceneToFile(Model *model, const std::string &filename,
+                                    bool embedImages = false,
+                                    bool embedBuffers = false,
+                                    bool prettyPrint = true,
+                                    bool writeBinary = false) {
+  json output;
   std::string defaultBinFilename = GetBaseFilename(filename);
   std::string defaultBinFileExt = ".bin";
   std::string::size_type pos =
@@ -5343,6 +5553,8 @@ bool TinyGLTF::WriteGltfSceneToFile(Model *model, const std::string &filename,
   if (baseDir.empty()) {
     baseDir = "./";
   }
+ /// Serialize all properties except buffers and images.
+ SerializeGltfModel(model, output);
 
   // BUFFERS
   std::vector<std::string> usedUris;
@@ -5382,27 +5594,6 @@ bool TinyGLTF::WriteGltfSceneToFile(Model *model, const std::string &filename,
   }
   output["buffers"] = buffers;
 
-  // BUFFERVIEWS
-  json bufferViews;
-  for (unsigned int i = 0; i < model->bufferViews.size(); ++i) {
-    json bufferView;
-    SerializeGltfBufferView(model->bufferViews[i], bufferView);
-    bufferViews.push_back(bufferView);
-  }
-  output["bufferViews"] = bufferViews;
-
-  // Extensions used
-  if (model->extensionsUsed.size()) {
-    SerializeStringArrayProperty("extensionsUsed", model->extensionsUsed,
-                                 output);
-  }
-
-  // Extensions required
-  if (model->extensionsRequired.size()) {
-    SerializeStringArrayProperty("extensionsRequired",
-                                 model->extensionsRequired, output);
-  }
-
   // IMAGES
   if (model->images.size()) {
     json images;
@@ -5415,128 +5606,6 @@ bool TinyGLTF::WriteGltfSceneToFile(Model *model, const std::string &filename,
       images.push_back(image);
     }
     output["images"] = images;
-  }
-
-  // MATERIALS
-  if (model->materials.size()) {
-    json materials;
-    for (unsigned int i = 0; i < model->materials.size(); ++i) {
-      json material;
-      SerializeGltfMaterial(model->materials[i], material);
-      materials.push_back(material);
-    }
-    output["materials"] = materials;
-  }
-
-  // MESHES
-  if (model->meshes.size()) {
-    json meshes;
-    for (unsigned int i = 0; i < model->meshes.size(); ++i) {
-      json mesh;
-      SerializeGltfMesh(model->meshes[i], mesh);
-      meshes.push_back(mesh);
-    }
-    output["meshes"] = meshes;
-  }
-
-  // NODES
-  if (model->nodes.size()) {
-    json nodes;
-    for (unsigned int i = 0; i < model->nodes.size(); ++i) {
-      json node;
-      SerializeGltfNode(model->nodes[i], node);
-      nodes.push_back(node);
-    }
-    output["nodes"] = nodes;
-  }
-
-  // SCENE
-  if (model->defaultScene > -1) {
-    SerializeNumberProperty<int>("scene", model->defaultScene, output);
-  }
-
-  // SCENES
-  if (model->scenes.size()) {
-    json scenes;
-    for (unsigned int i = 0; i < model->scenes.size(); ++i) {
-      json currentScene;
-      SerializeGltfScene(model->scenes[i], currentScene);
-      scenes.push_back(currentScene);
-    }
-    output["scenes"] = scenes;
-  }
-
-  // SKINS
-  if (model->skins.size()) {
-    json skins;
-    for (unsigned int i = 0; i < model->skins.size(); ++i) {
-      json skin;
-      SerializeGltfSkin(model->skins[i], skin);
-      skins.push_back(skin);
-    }
-    output["skins"] = skins;
-  }
-
-  // TEXTURES
-  if (model->textures.size()) {
-    json textures;
-    for (unsigned int i = 0; i < model->textures.size(); ++i) {
-      json texture;
-      SerializeGltfTexture(model->textures[i], texture);
-      textures.push_back(texture);
-    }
-    output["textures"] = textures;
-  }
-
-  // SAMPLERS
-  if (model->samplers.size()) {
-    json samplers;
-    for (unsigned int i = 0; i < model->samplers.size(); ++i) {
-      json sampler;
-      SerializeGltfSampler(model->samplers[i], sampler);
-      samplers.push_back(sampler);
-    }
-    output["samplers"] = samplers;
-  }
-
-  // CAMERAS
-  if (model->cameras.size()) {
-    json cameras;
-    for (unsigned int i = 0; i < model->cameras.size(); ++i) {
-      json camera;
-      SerializeGltfCamera(model->cameras[i], camera);
-      cameras.push_back(camera);
-    }
-    output["cameras"] = cameras;
-  }
-
-  // EXTENSIONS
-  SerializeExtensionMap(model->extensions, output);
-
-  // LIGHTS as KHR_lights_cmn
-  if (model->lights.size()) {
-    json lights;
-    for (unsigned int i = 0; i < model->lights.size(); ++i) {
-      json light;
-      SerializeGltfLight(model->lights[i], light);
-      lights.push_back(light);
-    }
-    json khr_lights_cmn;
-    khr_lights_cmn["lights"] = lights;
-    json ext_j;
-
-    if (output.find("extensions") != output.end()) {
-      ext_j = output["extensions"];
-    }
-
-    ext_j["KHR_lights_punctual"] = khr_lights_cmn;
-
-    output["extensions"] = ext_j;
-  }
-
-  // EXTRAS
-  if (model->extras.Type() != NULL_TYPE) {
-    SerializeValue("extras", model->extras, output);
   }
 
   if (writeBinary) {

--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -817,7 +817,7 @@ struct SpotLight {
   double innerConeAngle;
   double outerConeAngle;
 
-  SpotLight() : innerConeAngle(0.0), outerConeAngle(0.7853981634) { }
+  SpotLight() : innerConeAngle(0.0), outerConeAngle(0.7853981634) {}
 
   bool operator==(const SpotLight &) const;
 
@@ -1060,7 +1060,6 @@ class TinyGLTF {
   bool LoadFromString(Model *model, std::string *err, std::string *warn,
                       const char *str, const unsigned int length,
                       const std::string &base_dir, unsigned int check_sections);
-
 
   const unsigned char *bin_data_;
   size_t bin_size_;
@@ -3704,17 +3703,16 @@ static bool ParsePerspectiveCamera(PerspectiveCamera *camera, std::string *err,
   return true;
 }
 
-static bool ParseSpotLight(SpotLight *light,
-                           std::string *err, const json &o) {
-    ParseNumberProperty(&light->innerConeAngle, err, o, "innerConeAngle", false);
-    ParseNumberProperty(&light->outerConeAngle, err, o, "outerConeAngle", false);
+static bool ParseSpotLight(SpotLight *light, std::string *err, const json &o) {
+  ParseNumberProperty(&light->innerConeAngle, err, o, "innerConeAngle", false);
+  ParseNumberProperty(&light->outerConeAngle, err, o, "outerConeAngle", false);
 
-    ParseExtensionsProperty(&light->extensions, err, o);
-    ParseExtrasProperty(&light->extras, o);
+  ParseExtensionsProperty(&light->extensions, err, o);
+  ParseExtrasProperty(&light->extras, o);
 
-    // TODO(syoyo): Validate parameter values.
+  // TODO(syoyo): Validate parameter values.
 
-    return true;
+  return true;
 }
 
 static bool ParseOrthographicCamera(OrthographicCamera *camera,
@@ -3823,42 +3821,42 @@ static bool ParseCamera(Camera *camera, std::string *err, const json &o) {
 }
 
 static bool ParseLight(Light *light, std::string *err, const json &o) {
-    if (!ParseStringProperty(&light->type, err, o, "type", true)) {
-        return false;
+  if (!ParseStringProperty(&light->type, err, o, "type", true)) {
+    return false;
+  }
+
+  if (light->type == "spot") {
+    if (o.find("spot") == o.end()) {
+      if (err) {
+        std::stringstream ss;
+        ss << "Spot light description not found." << std::endl;
+        (*err) += ss.str();
+      }
+      return false;
     }
 
-    if (light->type == "spot") {
-        if (o.find("spot") == o.end()) {
-            if (err) {
-                std::stringstream ss;
-                ss << "Spot light description not found." << std::endl;
-                (*err) += ss.str();
-            }
-            return false;
-        }
-
-        const json &v = o.find("spot").value();
-        if (!v.is_object()) {
-            if (err) {
-                std::stringstream ss;
-                ss << "\"spot\" is not a JSON object." << std::endl;
-                (*err) += ss.str();
-            }
-            return false;
-        }
-
-        if (!ParseSpotLight(&light->spot, err, v.get<json>())) {
-            return false;
-        }
+    const json &v = o.find("spot").value();
+    if (!v.is_object()) {
+      if (err) {
+        std::stringstream ss;
+        ss << "\"spot\" is not a JSON object." << std::endl;
+        (*err) += ss.str();
+      }
+      return false;
     }
 
-    ParseStringProperty(&light->name, err, o, "name", false);
-    ParseNumberArrayProperty(&light->color, err, o, "color", false);
-    ParseNumberProperty(&light->range, err, o, "range", false);
-    ParseNumberProperty(&light->intensity, err, o, "intensity", false);
-    ParseExtensionsProperty(&light->extensions, err, o);
-    ParseExtrasProperty(&(light->extras), o);
-    return true;
+    if (!ParseSpotLight(&light->spot, err, v.get<json>())) {
+      return false;
+    }
+  }
+
+  ParseStringProperty(&light->name, err, o, "name", false);
+  ParseNumberArrayProperty(&light->color, err, o, "color", false);
+  ParseNumberProperty(&light->range, err, o, "range", false);
+  ParseNumberProperty(&light->intensity, err, o, "intensity", false);
+  ParseExtensionsProperty(&light->extensions, err, o);
+  ParseExtrasProperty(&(light->extras), o);
+  return true;
 }
 
 bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
@@ -5113,9 +5111,9 @@ static void SerializeGltfMesh(Mesh &mesh, json &o) {
 }
 
 static void SerializeSpotLight(SpotLight &spot, json &o) {
-    SerializeNumberProperty("innerConeAngle", spot.innerConeAngle, o);
-    SerializeNumberProperty("outerConeAngle", spot.outerConeAngle, o);
-    SerializeExtensionMap(spot.extensions, o);
+  SerializeNumberProperty("innerConeAngle", spot.innerConeAngle, o);
+  SerializeNumberProperty("outerConeAngle", spot.outerConeAngle, o);
+  SerializeExtensionMap(spot.extensions, o);
 }
 
 static void SerializeGltfLight(Light &light, json &o) {
@@ -5268,7 +5266,6 @@ static void SerializeGltfTexture(Texture &texture, json &o) {
 /// Serialize all properties except buffers and images.
 ///
 static void SerializeGltfModel(Model *model, json &o) {
-
   // ACCESSORS
   json accessors;
   for (unsigned int i = 0; i < model->accessors.size(); ++i) {
@@ -5296,7 +5293,6 @@ static void SerializeGltfModel(Model *model, json &o) {
   SerializeGltfAsset(model->asset, asset);
   o["asset"] = asset;
 
-
   // BUFFERVIEWS
   json bufferViews;
   for (unsigned int i = 0; i < model->bufferViews.size(); ++i) {
@@ -5308,8 +5304,7 @@ static void SerializeGltfModel(Model *model, json &o) {
 
   // Extensions used
   if (model->extensionsUsed.size()) {
-    SerializeStringArrayProperty("extensionsUsed", model->extensionsUsed,
-                                 o);
+    SerializeStringArrayProperty("extensionsUsed", model->extensionsUsed, o);
   }
 
   // Extensions required
@@ -5441,8 +5436,7 @@ static void SerializeGltfModel(Model *model, json &o) {
   }
 }
 
-static bool WriteGltfStream(std::ostream &stream,
-                            const std::string &content) {
+static bool WriteGltfStream(std::ostream &stream, const std::string &content) {
   stream << content << std::endl;
   return true;
 }
@@ -5455,8 +5449,7 @@ static bool WriteGltfFile(const std::string &output,
 }
 
 static void WriteBinaryGltfStream(std::ostream &stream,
-                          const std::string &content) {
-
+                                  const std::string &content) {
   const std::string header = "glTF";
   const int version = 2;
   const int padding_size = content.size() % 4;
@@ -5473,9 +5466,9 @@ static void WriteBinaryGltfStream(std::ostream &stream,
   const int model_length = int(content.size()) + padding_size;
   const int model_format = 0x4E4F534A;
   stream.write(reinterpret_cast<const char *>(&model_length),
-                 sizeof(model_length));
+               sizeof(model_length));
   stream.write(reinterpret_cast<const char *>(&model_format),
-                 sizeof(model_format));
+               sizeof(model_format));
   stream.write(content.c_str(), content.size());
 
   // Chunk must be multiplies of 4, so pad with spaces
@@ -5492,8 +5485,8 @@ static void WriteBinaryGltfFile(const std::string &output,
 }
 
 bool TinyGLTF::WriteGltfSceneToStream(Model *model, std::ostream &stream,
-                                    bool prettyPrint = true,
-                                    bool writeBinary = false) {
+                                      bool prettyPrint = true,
+                                      bool writeBinary = false) {
   json output;
 
   /// Serialize all properties except buffers and images.
@@ -5516,8 +5509,9 @@ bool TinyGLTF::WriteGltfSceneToStream(Model *model, std::ostream &stream,
       json image;
 
       std::string dummystring = "";
-      // UpdateImageObject need baseDir but only uses it if embededImages is enable,
-      // since we won't write separte images when writing to a stream we use a dummystring
+      // UpdateImageObject need baseDir but only uses it if embededImages is
+      // enable, since we won't write separte images when writing to a stream we
+      // use a dummystring
       UpdateImageObject(model->images[i], dummystring, int(i), false,
                         &this->WriteImageData, this->write_image_user_data_);
       SerializeGltfImage(model->images[i], image);
@@ -5553,8 +5547,8 @@ bool TinyGLTF::WriteGltfSceneToFile(Model *model, const std::string &filename,
   if (baseDir.empty()) {
     baseDir = "./";
   }
- /// Serialize all properties except buffers and images.
- SerializeGltfModel(model, output);
+  /// Serialize all properties except buffers and images.
+  SerializeGltfModel(model, output);
 
   // BUFFERS
   std::vector<std::string> usedUris;


### PR DESCRIPTION
**Summary:**
Added functionality to serialize glTF model to a stream using function:
`WriteGltfSceneToStream(Model *model, std::ostream &stream, bool prettyPrint, bool writeBinary)`
Note: `WriteGltfSceneToStream` will always embed buffers and images.

**Examples:**
This feature can be used to serialize to memory, issue: #98. Using code:
```c++
#define TINYGLTF_IMPLEMENTATION
#define STB_IMAGE_IMPLEMENTATION
#define STB_IMAGE_WRITE_IMPLEMENTATION

#ifdef _WIN32
#define STBI_MSC_SECURE_CRT
#endif

#include <sstream>
#include "tinygltf.h"

int main(int argc, char *argv[]) {

  tinygltf::Model model;
  tinygltf::TinyGLTF gltfapi;
  std::string err;
  std::string warn;

  gltfapi.LoadASCIIFromFile(&model, &err, &warn, "/path/to/model.gltf");
  
  std::stringstream ss;
  gltfapi.WriteGltfSceneToStream(&model, ss, false, false);
  std::string gltf_as_string= ss.str();

return 0;
}
```

This feature also solves the problem to serialize glTF-models to UTF-8 paths on Windows. On Windows, [you must use 8bit ANSI or UTF16 for filenames]( https://stackoverflow.com/a/30831401). Tinygltf don’t support `wstrings` as filenames. This pull request provides an option for the user to open the stream with `wstring` (or `filesystem::path` as in the example below) to fully support UTF8-path on Windows
```c++
#define TINYGLTF_IMPLEMENTATION
#define STB_IMAGE_IMPLEMENTATION
#define STB_IMAGE_WRITE_IMPLEMENTATION
#define STBI_MSC_SECURE_CRT

#include <filesystem> // Supported in c++17 on Windows
#include <iostream>
#include "tinygltf.h"

int main(int argc, char *argv[]) {
  tinygltf::Model model;
  tinygltf::TinyGLTF gltfapi;
  std::string err;
  std::string warn;

  gltfapi.LoadASCIIFromFile(&model, &err, &warn, "/path/to/model.gltf");
  
  // write input model to path/to/こんにちは.gltf
  std::ofstream stream(filesystem::u8path("path/to/こんにちは.gltf"));
  gltfapi.WriteGltfSceneToStream(&model, stream, false, false);

  // and it can also write to binary
  std::ofstream binary_stream(filesystem::u8path("path/to/こんにちは.glb", std::ios::binary));
  gltfapi.WriteGltfSceneToStream(&model, binary_stream, false, true);
  // Note writeBinary argument is true
return 0;
}
```

**Code Changes:**
 All serialization except for buffers and images have been moved from `WriteGltfSceneToFile` to a new function, `SerializeGltfModel`. This function is used both by `WriteGltfSceneToFile` and `WriteGltfSceneToStream`, however each implements it's own version for serialization of buffers and images (since `WriteGltfSceneToFile` can write separate outputs).
