### PR TITLE
Explicitly use the correct constructor for empty object

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -4828,7 +4828,7 @@ static void SerializeExtensionMap(ExtensionMap &extensions, json &o) {
       if (!(extIt->first.empty())) {  // name should not be empty, but for sure
         // create empty object so that an extension name is still included in
         // json.
-        extMap[extIt->first] = json({});
+        extMap[extIt->first] = json(std::initializer_list<nlohmann::detail::json_ref<nlohmann::basic_json<>>>());
       }
     }
   }


### PR DESCRIPTION
On one of my build agents (pretty old system with GCC 7.4 on Ubuntu 16.04), I got the objects serialized as `null` (reminds me of https://github.com/syoyo/tinygltf/issues/97). My workaround is pretty simple, but I'm using the `nlohmann::detail` namespace which feels a little hacky.