### PR TITLE
remove extra #endif in examples/basic app

### DIFF
--- a/examples/basic/main.cpp
+++ b/examples/basic/main.cpp
@@ -333,7 +333,6 @@ int main(int argc, char **argv) {
 #ifdef __APPLE__
   glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
 #endif
-#endif
 
   Window window = Window(800, 600, "TinyGLTF basic example");
   glfwMakeContextCurrent(window.window);


### PR DESCRIPTION
Hi,
I get the following error compiling on macOS:

    examples/basic/main.cpp:336:2: error: #endif without #if

This PR removes the useless #endif.