### PR TITLE
Fixed saving of alphaMode if not OPAQUE

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -5412,12 +5412,8 @@ static void SerializeGltfMaterial(Material &material, json &o) {
     SerializeNumberProperty("alphaCutoff", material.alphaCutoff, o);
   }
 
-  if (material.alphaMode.compare("OPAQUE") == 0) {
+  if (material.alphaMode.compare("OPAQUE") != 0) {
     SerializeStringProperty("alphaMode", material.alphaMode, o);
-  }
-
-  if (!TINYGLTF_DOUBLE_EQUAL(material.alphaCutoff, 0.5)) {
-    SerializeNumberProperty("alphaCutoff", material.alphaCutoff, o);
   }
 
   o["doubleSided"] = json(material.doubleSided);


### PR DESCRIPTION
resolves #187 

Removed duplicated code for alphaCutoff