### PR TITLE
Emissive factor defaults

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -3743,8 +3743,22 @@ static bool ParsePbrMetallicRoughness(PbrMetallicRoughness *pbr,
 static bool ParseMaterial(Material *material, std::string *err, const json &o) {
   ParseStringProperty(&material->name, err, o, "name", /* required */ false);
 
-  ParseNumberArrayProperty(&material->emissiveFactor, err, o, "emissiveFactor",
-                           /* required */ false);
+  if(ParseNumberArrayProperty(&material->emissiveFactor, err, o, "emissiveFactor",
+                           /* required */ false)) {
+    if (material->emissiveFactor.size() != 3) {
+      if (err) {
+        (*err) +=
+            "Array length of `emissiveFactor` parameter in "
+            "material must be 3, but got " +
+            std::to_string(material->emissiveFactor.size()) + "\n";
+      }
+      return false;
+    }
+  }
+   else {
+    // fill with default values
+    material->emissiveFactor = {1.0, 1.0, 1.0};
+  }
 
   ParseStringProperty(&material->alphaMode, err, o, "alphaMode",
                       /* required */ false);

--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -3757,7 +3757,7 @@ static bool ParseMaterial(Material *material, std::string *err, const json &o) {
   }
    else {
     // fill with default values
-    material->emissiveFactor = {1.0, 1.0, 1.0};
+    material->emissiveFactor = {0.0, 0.0, 0.0};
   }
 
   ParseStringProperty(&material->alphaMode, err, o, "alphaMode",


### PR DESCRIPTION
Default material array values were only set for `baseColorFactor`, not for `emissiveFactor`. This caused a mismatch between material data after writing and parsing again.

This PR sets the default values for `emissiveFactor` as well.

Question: I noticed that there is currently some inconsistency between which default values are always set to defaults and/or serialized and which aren't. For example, node translation/rotation/scale is just parsed/serialized as-is, ignoring defaults. What is your preferred approach?