### PR TITLE
allow scenes without nodes

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -4563,7 +4563,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
         }
         const json &o = it->get<json>();
         std::vector<int> nodes;
-        ParseIntegerArrayProperty(&nodes, err, o, "nodes", false));
+        ParseIntegerArrayProperty(&nodes, err, o, "nodes", false);
 
         Scene scene;
         scene.nodes = std::move(nodes);

--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -4563,9 +4563,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
         }
         const json &o = it->get<json>();
         std::vector<int> nodes;
-        if (!ParseIntegerArrayProperty(&nodes, err, o, "nodes", false)) {
-          return false;
-        }
+        ParseIntegerArrayProperty(&nodes, err, o, "nodes", false));
 
         Scene scene;
         scene.nodes = std::move(nodes);


### PR DESCRIPTION
`nodes` is not a required field in `scene` so we shouldn't abort if we don't find it