### PR TITLE
Do not set target on bufferView pointing to animation data

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -5526,7 +5526,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
   // Assign missing bufferView target types
   // - Look for missing Mesh indices
-  // - Look for missing bufferView targets
+  // - Look for missing Mesh attributes
   for (auto &mesh : model->meshes) {
     for (auto &primitive : mesh.primitives) {
       if (primitive.indices >
@@ -5554,14 +5554,11 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
         // we could optionally check if acessors' bufferView type is Scalar, as
         // it should be
       }
-    }
-  }
-  // find any missing targets, must be an array buffer type if not fulfilled
-  // from previous check
-  for (auto &bufferView : model->bufferViews) {
-    if (bufferView.target == 0)  // missing target type
-    {
-      bufferView.target = TINYGLTF_TARGET_ARRAY_BUFFER;
+
+      for (auto &attribute : primitive.attributes) {
+        model->bufferViews[model->accessors[attribute.second].bufferView]
+            .target = TINYGLTF_TARGET_ARRAY_BUFFER;
+      }
     }
   }
 


### PR DESCRIPTION
I was implementing animations and creating OpenGL buffers based on BufferView `target` value. It is nice that tinygltf sets target correctly for Indices and Attributes, but BufferView can point to other type of data that not necessarily will land in GPU buffer. Probably that is why `target` value in gltf specification is optional.

https://github.com/syoyo/tinygltf/issues/116#issuecomment-444569685
After reading this I can add that this was maybe safe but not very useful. I propose to leave target value as 0 for non vertex indices and non vertex attribute data.