### PR TITLE
Initialize defaultScene to -1

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -1141,7 +1141,7 @@ class Model {
   std::vector<Scene> scenes;
   std::vector<Light> lights;
 
-  int defaultScene;
+  int defaultScene = -1;
   std::vector<std::string> extensionsUsed;
   std::vector<std::string> extensionsRequired;
 


### PR DESCRIPTION
To prevent undefined behavior if the model is serialized without defaultScene being set explicitly.