### PR TITLE
Reading copyright field in ParseAsset()

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -3513,6 +3513,7 @@ static bool ParseAsset(Asset *asset, std::string *err, const json &o,
   ParseStringProperty(&asset->version, err, o, "version", true, "Asset");
   ParseStringProperty(&asset->generator, err, o, "generator", false, "Asset");
   ParseStringProperty(&asset->minVersion, err, o, "minVersion", false, "Asset");
+  ParseStringProperty(&asset->copyright, err, o, "copyright", false, "Asset");
 
   ParseExtensionsProperty(&asset->extensions, err, o);
 


### PR DESCRIPTION
Added missing copyright read in the ParseAsset() function.