### PR TITLE
Avoid duplicating path string in ExpandFilePath

### DIFF
--- a/tiny_gltf.h.bak
+++ b/tiny_gltf.h.bak
@@ -1955,8 +1955,8 @@ static std::string FindFile(const std::vector<std::string> &paths,
   }
 
   for (size_t i = 0; i < paths.size(); i++) {
-    std::string absPath = JoinPath(paths[i], filepath);
-    fs->ExpandFilePath(&absPath, fs->user_data);
+    std::string absPath =
+        fs->ExpandFilePath(JoinPath(paths[i], filepath), fs->user_data);
     if (fs->FileExists(absPath, fs->user_data)) {
       return absPath;
     }
@@ -2435,14 +2435,15 @@ bool FileExists(const std::string &abs_filename, void *) {
   return ret;
 }
 
-void ExpandFilePath(std::string *filepath, void *) {
+std::string ExpandFilePath(const std::string &filepath, void *) {
 #ifdef _WIN32
-  DWORD len = ExpandEnvironmentStringsA(filepath->c_str(), NULL, 0);
-  std::string s;
-  s.reserve(len);
-  ExpandEnvironmentStringsA(filepath->c_str(), s.data(), len);
+  DWORD len = ExpandEnvironmentStringsA(filepath.c_str(), NULL, 0);
+  char *str = new char[len];
+  ExpandEnvironmentStringsA(filepath.c_str(), str, len);
 
-  *filepath = std::move(s);
+  std::string s(str);
+
+  delete[] str;
 
   return s;
 #else
@@ -2450,22 +2451,23 @@ void ExpandFilePath(std::string *filepath, void *) {
 #if defined(TARGET_OS_IPHONE) || defined(TARGET_IPHONE_SIMULATOR) || \
     defined(__ANDROID__) || defined(__EMSCRIPTEN__)
   // no expansion
-  return;
+  std::string s = filepath;
 #else
-  if (filepath->empty()) {
-    return;
-  }
-
   std::string s;
   wordexp_t p;
 
+  if (filepath.empty()) {
+    return "";
+  }
+
   // Quote the string to keep any spaces in filepath intact.
-  std::string quoted_path = "\"" + *filepath + "\"";
+  std::string quoted_path = "\"" + filepath + "\"";
   // char** w;
   int ret = wordexp(quoted_path.c_str(), &p, 0);
   if (ret) {
     // err
-    return;
+    s = filepath;
+    return s;
   }
 
   // Use first element only.
@@ -2473,12 +2475,12 @@ void ExpandFilePath(std::string *filepath, void *) {
     s = std::string(p.we_wordv[0]);
     wordfree(&p);
   } else {
-    s = *filepath;
+    s = filepath;
   }
 
 #endif
 
-  *filepath = std::move(s);
+  return s;
 #endif
 }
 


### PR DESCRIPTION
Small change to remove a couple of string duplication/allocations in ExpandFilePath