### PR TITLE
Ensures only valid bufferViews are mentioned in accessor

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -6500,7 +6500,8 @@ static void SerializeExtensionMap(const ExtensionMap &extensions, json &o) {
 }
 
 static void SerializeGltfAccessor(Accessor &accessor, json &o) {
-  SerializeNumberProperty<int>("bufferView", accessor.bufferView, o);
+  if (accessor.bufferView >= 0)
+    SerializeNumberProperty<int>("bufferView", accessor.bufferView, o);
 
   if (accessor.byteOffset != 0.0)
     SerializeNumberProperty<int>("byteOffset", int(accessor.byteOffset), o);


### PR DESCRIPTION
This change allows specification of an accessor without a bufferView and checks that bufferView index in an accessor is not negative.