### PR TITLE
cast size_t to uint_64_t for rapidjson serialization

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -6274,6 +6274,13 @@ static void SerializeNumberProperty(const std::string &key, T number,
   JsonAddMember(obj, key.c_str(), json(number));
 }
 
+#ifdef TINYGLTF_USE_RAPIDJSON
+template <>
+void SerializeNumberProperty(const std::string &key, size_t number, json &obj) {
+  JsonAddMember(obj, key.c_str(), json(static_cast<uint64_t>(number)));
+}
+#endif
+
 template <typename T>
 static void SerializeNumberArrayProperty(const std::string &key,
                                          const std::vector<T> &value,


### PR DESCRIPTION
GenericValue does not handle size_t explicitly, making tinygltf to not compile when using rapidjson. Adding an explicit template instantiation for SerializeNumberProperty<size_t> that casts to `uint64_t` fixes this.