### PR TITLE
TINYGLTF_PRESERVE_IMAGE_CHANNELS

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ if (!ret) {
 * `TINYGLTF_NO_INCLUDE_STB_IMAGE_WRITE `: Disable including `stb_image_write.h` from within `tiny_gltf.h` because it has been already included before or you want to include it using custom path before including `tiny_gltf.h`.
 * `TINYGLTF_USE_RAPIDJSON` : Use RapidJSON as a JSON parser/serializer. RapidJSON files are not included in TinyGLTF repo. Please set an include path to RapidJSON if you enable this featrure.
 * `TINYGLTF_USE_CPP14` : Use C++14 feature(requires C++14 compiler). This may give better performance than C++11.
-
+* `TINYGLTF_PRESERVE_IMAGE_CHANNELS` : Load images as is, without extending them to four channels.
 
 ### Saving gltTF 2.0 model
 

--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -2313,7 +2313,12 @@ bool LoadImageData(Image *image, const int image_idx, std::string *err,
 
   // force 32-bit textures for common Vulkan compatibility. It appears that
   // some GPU drivers do not support 24-bit images for Vulkan
+  #ifdef TINYGLTF_PRESERVE_IMAGE_CHANNELS
+  req_comp = 0;
+  #else
   req_comp = 4;
+  #endif
+
   int bits = 8;
   int pixel_type = TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE;
 
@@ -2384,6 +2389,10 @@ bool LoadImageData(Image *image, const int image_idx, std::string *err,
       return false;
     }
   }
+
+  #ifdef TINYGLTF_PRESERVE_IMAGE_CHANNELS
+  req_comp = comp;
+  #endif
 
   image->width = w;
   image->height = h;


### PR DESCRIPTION
It might be useful to allow user to load image as is, without
complementing image channels to four.

One notable example is using both occlusion-metallic-roughness and pure
occlusion textures in project: user might use component count (1 vs 3)
to determine whether texture encodes for pure occlusion or OMR.

To do so, out should enable `TINYGLTF_PRESERVE_IMAGE_CHANNELS` compile option.