### PR TITLE
check correct `extensionsUsed` for serialization

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -7471,7 +7471,7 @@ static void SerializeGltfModel(Model *model, json &o) {
   }
 
   // Extensions used
-  if (model->extensionsUsed.size()) {
+  if (extensionsUsed.size()) {
     SerializeStringArrayProperty("extensionsUsed", extensionsUsed, o);
   }
 


### PR DESCRIPTION
Check the size of the correct `extensionsUsed` variable before serialization.