### PR TITLE
Add (void)err for handling unused variable warning

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -4472,6 +4472,7 @@ static bool GetAttributeForAllPoints(uint32_t componentType, draco::Mesh *mesh,
 static bool ParseDracoExtension(Primitive *primitive, Model *model,
                                 std::string *err,
                                 const Value &dracoExtensionValue) {
+  (void)err;
   auto bufferViewValue = dracoExtensionValue.Get("bufferView");
   if (!bufferViewValue.IsInt()) return false;
   auto attributesValue = dracoExtensionValue.Get("attributes");


### PR DESCRIPTION
I saw in the `ParseExtensionsProperty`(3667) function,
unused variable err argument is wrapped with (void) keword.

I think err argument in the `ParseDracoExtension`(4472) is exactly
same situation with the above one.

For consistency, I think it need to be added (void)err in the
`ParseDracoExtension` function.