### PR TITLE
Delete unused variable initialization code

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -4533,7 +4533,6 @@ static bool ParseDracoExtension(Primitive *primitive, Model *model,
 
     int dracoAttributeIndex = attribute.second.Get<int>();
     const auto pAttribute = mesh->GetAttributeByUniqueId(dracoAttributeIndex);
-    const auto pBuffer = pAttribute->buffer();
     const auto componentType =
         model->accessors[primitiveAttribute->second].componentType;
 


### PR DESCRIPTION
Sorry for similar PR continuously.

Line 4536 in tinygltf.h file, there is unused variable initialization code like below.
```c++
    const auto pBuffer = pAttribute->buffer();
```

gcc compiler complained about that unused variable. 

I found there is **no side-effect** in  `pAttribute->buffer()` call and also pBuffer variable is **never used**. Therefore I delete that line entirely.