### PR TITLE
add missing switch case for binary

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -3192,6 +3192,7 @@ static bool ParseJsonAsValue(Value *ret, const json &o) {
       break;
     case json::value_t::null:
     case json::value_t::discarded:
+    case json::value_t::binary:
       // default:
       break;
   }


### PR DESCRIPTION
with warnings cranked up and warnings-as-errors enabled, the compiler throws an error due to this switch missing a case for binary.  this makes the ignore explicit in order for compilation to proceed.