### PR TITLE
GitHub actions ci fix

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -G "Visual Studio 16 2019" -DTINYGLTF_BUILD_LOADER_EXAMPLE=On -DTINYGLTF_BUILD_GL_EXAMPLES=Off -DTINYGLTF_BUILD_VALIDATOR_EXAMPLE=On ..
+          cmake -G "Visual Studio 16 2019" -A x64 -DTINYGLTF_BUILD_LOADER_EXAMPLE=On -DTINYGLTF_BUILD_GL_EXAMPLES=Off -DTINYGLTF_BUILD_VALIDATOR_EXAMPLE=On ..
           cd ..
       - name: Build
         run: cmake --build build --config Release

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -62,7 +62,8 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -G "Visual Studio 16 2019" -A x64 -DTINYGLTF_BUILD_LOADER_EXAMPLE=On -DTINYGLTF_BUILD_GL_EXAMPLES=Off -DTINYGLTF_BUILD_VALIDATOR_EXAMPLE=On ..
+          cmake --help
+          cmake -G "Visual Studio 16 2019 Win64" -A x64 -DTINYGLTF_BUILD_LOADER_EXAMPLE=On -DTINYGLTF_BUILD_GL_EXAMPLES=Off -DTINYGLTF_BUILD_VALIDATOR_EXAMPLE=On ..
           cd ..
       - name: Build
         run: cmake --build build --config Release

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -47,7 +47,8 @@ jobs:
             sudo apt-get install -y mingw-w64
             x86_64-w64-mingw32-g++ -std=c++11 -o loader_example loader_example.cc
 
-  # Windows(x64) + Visual Studio 2019 build
+  # Windows(x64) + Visual Studio 2022 build
+  # Assume windows-latest have VS2022 installed
   build-windows-msvc:
 
     runs-on: windows-latest
@@ -63,7 +64,7 @@ jobs:
           mkdir build
           cd build
           cmake --help
-          cmake -G "Visual Studio 16 2019 Win64" -A x64 -DTINYGLTF_BUILD_LOADER_EXAMPLE=On -DTINYGLTF_BUILD_GL_EXAMPLES=Off -DTINYGLTF_BUILD_VALIDATOR_EXAMPLE=On ..
+          cmake -G "Visual Studio 17 2022" -A x64 -DTINYGLTF_BUILD_LOADER_EXAMPLE=On -DTINYGLTF_BUILD_GL_EXAMPLES=Off -DTINYGLTF_BUILD_VALIDATOR_EXAMPLE=On ..
           cd ..
       - name: Build
         run: cmake --build build --config Release


### PR DESCRIPTION
VS2019  gone 😿 

https://github.com/actions/virtual-environments/issues/4856#issuecomment-1047801500

Raise VS version to 2022 to fix Github Actions build.


