### PR TITLE
Fix byte offset optionality for sparse accessor indices and values

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -4238,7 +4238,7 @@ static bool ParseSparseAccessor(Accessor *accessor, std::string *err,
   ParseIntegerProperty(&indices_buffer_view, err, indices_obj, "bufferView",
                        true);
   ParseIntegerProperty(&indices_byte_offset, err, indices_obj, "byteOffset",
-                       true);
+                       false);
   ParseIntegerProperty(&component_type, err, indices_obj, "componentType",
                        true);
 
@@ -4246,7 +4246,7 @@ static bool ParseSparseAccessor(Accessor *accessor, std::string *err,
   ParseIntegerProperty(&values_buffer_view, err, values_obj, "bufferView",
                        true);
   ParseIntegerProperty(&values_byte_offset, err, values_obj, "byteOffset",
-                       true);
+                       false);
 
   accessor->sparse.count = count;
   accessor->sparse.indices.bufferView = indices_buffer_view;


### PR DESCRIPTION
[`accessor.sparse.indices.byteOffset`](https://github.com/KhronosGroup/glTF/blob/main/specification/2.0/schema/accessor.sparse.indices.schema.json#L45) and [`accessor.sparse.values.byteOffset`](https://github.com/KhronosGroup/glTF/blob/main/specification/2.0/schema/accessor.sparse.values.schema.json#L22) are both optional with default values of zero. I tested with [`Accessor_Sparse_01.gltf`](https://github.com/KhronosGroup/glTF-Asset-Generator/blob/master/Output/Positive/Accessor_Sparse/Accessor_Sparse_01.gltf#L103-L112), which contains a sparse accessor without a `byteOffset` key for its `indices` and `values.`

```bash
./loader_example glTF-Asset-Generator/Output/Positive/Accessor_Sparse/Accessor_Sparse_01.gltf
```

Output before:

```txt
Reading ASCII glTF
Err: 'byteOffset' property is missing.
'byteOffset' property is missing.
```

Output after:

```txt
Reading ASCII glTF
```

The sample model test runner and unit tests still succeed.