### PR TITLE
Fixed find_last_of call in GetBaseFilename

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -2041,8 +2041,7 @@ static std::string GetBaseDir(const std::string &filepath) {
 }
 
 static std::string GetBaseFilename(const std::string &filepath) {
-  constexpr char path_separators[2] = { '/', '\\' };
-  auto idx = filepath.find_last_of(path_separators);
+  auto idx = filepath.find_last_of("/\\");
   if (idx != std::string::npos)
     return filepath.substr(idx + 1);
   return filepath;


### PR DESCRIPTION
this leads to a stack overflow on linux - it looks like this magically works on msvc though...

Already in use in vengi https://github.com/mgerhardy/vengi/commit/2c8716fbbe8be30eda99944c5291d373cd6610d1

https://www.cplusplus.com/reference/string/string/find_last_of/