### PR TITLE
fix images not beeing embeded into stream

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -7632,7 +7632,7 @@ bool TinyGLTF::WriteGltfSceneToStream(Model *model, std::ostream &stream,
       // UpdateImageObject need baseDir but only uses it if embeddedImages is
       // enabled, since we won't write separate images when writing to a stream
       // we
-      UpdateImageObject(model->images[i], dummystring, int(i), false,
+      UpdateImageObject(model->images[i], dummystring, int(i), true,
                         &this->WriteImageData, this->write_image_user_data_);
       SerializeGltfImage(model->images[i], image);
       JsonPushBack(images, std::move(image));


### PR DESCRIPTION
The documentation of `WriteGltfSceneToStream` states that `buffers and images will be embeded`. When testing I had quite some trouble to teach the exporter to include my images (I am building the gltf (including images) from scratch for exporting). I noticed `embedImages` was set to false when calling `WriteGltfSceneToStream`. I assume this is a bug, so this PR fixes that.