### PR TITLE
Sparse accessor: typo fix

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -6709,7 +6709,7 @@ static void SerializeGltfAccessor(Accessor &accessor, json &o) {
       {
           json values;
           SerializeNumberProperty<int>("bufferView", accessor.sparse.values.bufferView, values);
-          SerializeNumberProperty<int>("byteOffset", accessor.sparse.values.bufferView, values);
+          SerializeNumberProperty<int>("byteOffset", accessor.sparse.values.byteOffset, values);
           JsonAddMember(sparse, "values", std::move(values));
       }
       JsonAddMember(o, "sparse", std::move(sparse));


### PR DESCRIPTION
Sorry I made a mistake with accessor.sparse.values.byteOffset.

The value is not used at all in some applications, so the test didn't detect it.

