### PR TITLE
Read from moved object

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -3671,7 +3671,8 @@ static bool ParseParameterProperty(Parameter *param, std::string *err,
     // Found a number array.
     return true;
   } else if (ParseNumberProperty(&param->number_value, err, o, prop, false)) {
-    return param->has_number_value = true;
+    param->has_number_value = true;
+    return true;
   } else if (ParseJSONProperty(&param->json_double_value, err, o, prop,
                                false)) {
     return true;

--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -3229,9 +3229,11 @@ static bool ParseJsonAsValue(Value *ret, const json &o) {
       break;
   }
 #endif
+  const bool isNotNull = val.Type() != NULL_TYPE;
+
   if (ret) *ret = std::move(val);
 
-  return val.Type() != NULL_TYPE;
+  return isNotNull;
 }
 
 static bool ParseExtrasProperty(Value *ret, const json &o) {


### PR DESCRIPTION
f4f5c3c - We should not read from object that was moved in previous line.
b12a54e - Second commit is just silencing warning. But also for me at firs read it looked like a mistake.