### PR TITLE
Auto detect C++14 standard version

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -66,6 +66,11 @@
 #include <string>
 #include <vector>
 
+//Auto-detect C++14 standard version
+#if !defined(TINYGLTF_USE_CPP14) && defined(__cplusplus) && (__cplusplus >= 201402L)
+#define TINYGLTF_USE_CPP14
+#endif
+
 #ifndef TINYGLTF_USE_CPP14
 #include <functional>
 #endif


### PR DESCRIPTION
This should auto-detect if tinygltf is being compiled against c++14 or newer standard, to enable the optimizations near the end of tiny_gltf.h. Note that MSVC requires '/Zc:__cplusplus' compiler flag so that __cplusplus is set correctly (https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/)