### PR TITLE
Fix UTF-8 filepath on LLVM MinGW

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -2597,7 +2597,7 @@ bool FileExists(const std::string &abs_filename, void *) {
   }
 #else
 #ifdef _WIN32
-#if defined(_MSC_VER) || defined(__GLIBCXX__)
+#if defined(_MSC_VER) || defined(__GLIBCXX__) || defined(_LIBCPP_VERSION)
   FILE *fp = nullptr;
   errno_t err = _wfopen_s(&fp, UTF8ToWchar(abs_filename).c_str(), L"rb");
   if (err != 0) {


### PR DESCRIPTION
When compiling using [llvm-mingw](https://github.com/mstorsjo/llvm-mingw) `LoadASCIIFromFile` fails to load .gltf files that reference files with Unicode characters in their name (tested on Windows using [Unicode❤♻Test](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/Unicode%E2%9D%A4%E2%99%BBTest)) resulting in `File not found : Unicode❤♻Binary.bin` error.

Because this is a Clang based MinGW compiler `__GLIBCXX__` is not defined and libc++ is used instead. Adding a check for `_LIBCPP_VERSION` define to `FileExists` enables proper checking for existence of Unicode paths and [Unicode❤♻Test/glTF](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/Unicode%E2%9D%A4%E2%99%BBTest/glTF)  successfully loads now.