### PR TITLE
Avoid multiple asset_manager definitions on Android

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -200,7 +200,11 @@ namespace tinygltf {
 
 #ifdef __ANDROID__
 #ifdef TINYGLTF_ANDROID_LOAD_FROM_ASSETS
+#ifdef TINYGLTF_IMPLEMENTATION
 AAssetManager *asset_manager = nullptr;
+#else
+extern AAssetManager *asset_manager;
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
Using TINYGLTF_IMPLEMENTATION to make the actual definition of the 'asset_manager' global variable.