### PR TITLE
propagate image writing failures

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -7023,7 +7023,7 @@ static void SerializeGltfBufferView(const BufferView &bufferView, json &o) {
   }
 }
 
-static void SerializeGltfImage(const Image &image, const std::string uri,
+static void SerializeGltfImage(const Image &image, const std::string &uri,
                                json &o) {
   // From 2.7.0, we look for `uri` parameter, not `Image.uri`
   // if uri is empty, the mimeType and bufferview should be set


### PR DESCRIPTION
Modifies UpdateImageObject() so that Returning false from the WriteImageDataFunction callback results in the WriteGltfScene*() call returning false.

Does not call WriteImageDataFunction if there is no image data.

Adds test case serialize-image-failure to verify the callback return code is able to cause an overall failure to save the gltf.

(patch created while revising https://github.com/syoyo/tinygltf/pull/393#issuecomment-1366290061)