### PR TITLE
Missed serialization texture sampler name fixed.

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -7440,6 +7440,9 @@ static void SerializeGltfNode(const Node &node, json &o) {
 }
 
 static void SerializeGltfSampler(const Sampler &sampler, json &o) {
+  if (!sampler.name.empty()) {
+    SerializeStringProperty("name", sampler.name, o);
+  }
   if (sampler.magFilter != -1) {
     SerializeNumberProperty("magFilter", sampler.magFilter, o);
   }


### PR DESCRIPTION
According to the glTF 2.0 specification it exists, the internal tinygltf structure contains 'name' field as well.