### PR TITLE
Added detail namespace to prevent json namespace conflicts

### DIFF
--- a/tests/tester.cc
+++ b/tests/tester.cc
@@ -16,10 +16,10 @@
 #include <sstream>
 #include <fstream>
 
-static detail::JsonDocument JsonConstruct(const char* str)
+static tinygltf::detail::JsonDocument JsonConstruct(const char* str)
 {
-  detail::JsonDocument doc;
-  detail::JsonParse(doc, str, strlen(str));
+  tinygltf::detail::JsonDocument doc;
+  tinygltf::detail::JsonParse(doc, str, strlen(str));
   return doc;
 }
 
@@ -275,9 +275,9 @@ TEST_CASE("parse-integer", "[bounds-checking]") {
 
     err.clear();
     {
-      detail::JsonDocument o;
+      tinygltf::detail::JsonDocument o;
       double nan = std::numeric_limits<double>::quiet_NaN();
-      tinygltf::detail::JsonAddMember(o, "int", detail::json(nan));
+      tinygltf::detail::JsonAddMember(o, "int", tinygltf::detail::json(nan));
       CHECK_FALSE(tinygltf::ParseIntegerProperty(
         &result, &err, o,
         "int", true));
@@ -321,9 +321,9 @@ TEST_CASE("parse-unsigned", "[bounds-checking]") {
 
     err.clear();
     {
-      detail::JsonDocument o;
+      tinygltf::detail::JsonDocument o;
       double nan = std::numeric_limits<double>::quiet_NaN();
-      tinygltf::detail::JsonAddMember(o, "int", detail::json(nan));
+      tinygltf::detail::JsonAddMember(o, "int", tinygltf::detail::json(nan));
       CHECK_FALSE(tinygltf::ParseUnsignedProperty(
         &result, &err, o,
         "int", true));

--- a/tests/tester.cc
+++ b/tests/tester.cc
@@ -16,10 +16,10 @@
 #include <sstream>
 #include <fstream>
 
-static JsonDocument JsonConstruct(const char* str)
+static detail::JsonDocument JsonConstruct(const char* str)
 {
-  JsonDocument doc;
-  JsonParse(doc, str, strlen(str));
+  detail::JsonDocument doc;
+  detail::JsonParse(doc, str, strlen(str));
   return doc;
 }
 
@@ -275,9 +275,9 @@ TEST_CASE("parse-integer", "[bounds-checking]") {
 
     err.clear();
     {
-      JsonDocument o;
+      detail::JsonDocument o;
       double nan = std::numeric_limits<double>::quiet_NaN();
-      tinygltf::JsonAddMember(o, "int", json(nan));
+      tinygltf::detail::JsonAddMember(o, "int", detail::json(nan));
       CHECK_FALSE(tinygltf::ParseIntegerProperty(
         &result, &err, o,
         "int", true));
@@ -321,9 +321,9 @@ TEST_CASE("parse-unsigned", "[bounds-checking]") {
 
     err.clear();
     {
-      JsonDocument o;
+      detail::JsonDocument o;
       double nan = std::numeric_limits<double>::quiet_NaN();
-      tinygltf::JsonAddMember(o, "int", json(nan));
+      tinygltf::detail::JsonAddMember(o, "int", detail::json(nan));
       CHECK_FALSE(tinygltf::ParseUnsignedProperty(
         &result, &err, o,
         "int", true));

--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -3292,7 +3292,7 @@ static bool ParseJsonAsValue(Value *ret, const ::detail::json &o) {
         val = Value(i);
       } else {
         double d = 0.0;
-        GetDouble(o, d);
+        detail::GetDouble(o, d);
         val = Value(d);
       }
       break;
@@ -6555,7 +6555,7 @@ bool TinyGLTF::LoadBinaryFromFile(Model *model, std::string *err,
 namespace detail {
 ::detail::json JsonFromString(const char *s) {
 #ifdef TINYGLTF_USE_RAPIDJSON
-  return ::detail::json(s, GetAllocator());
+  return ::detail::json(s, ::detail::GetAllocator());
 #else
   return ::detail::json(s);
 #endif
@@ -6563,7 +6563,7 @@ namespace detail {
 
 void JsonAssign(::detail::json &dest, const ::detail::json &src) {
 #ifdef TINYGLTF_USE_RAPIDJSON
-  dest.CopyFrom(src, GetAllocator());
+  dest.CopyFrom(src, ::detail::GetAllocator());
 #else
   dest = src;
 #endif
@@ -6574,7 +6574,7 @@ void JsonAddMember(::detail::json &o, const char *key, ::detail::json &&value) {
   if (!o.IsObject()) {
     o.SetObject();
   }
-  o.AddMember(json(key, GetAllocator()), std::move(value), GetAllocator());
+  o.AddMember(::detail::json(key, ::detail::GetAllocator()), std::move(value), ::detail::GetAllocator());
 #else
   o[key] = std::move(value);
 #endif
@@ -6582,7 +6582,7 @@ void JsonAddMember(::detail::json &o, const char *key, ::detail::json &&value) {
 
 void JsonPushBack(::detail::json &o, ::detail::json &&value) {
 #ifdef TINYGLTF_USE_RAPIDJSON
-  o.PushBack(std::move(value), GetAllocator());
+  o.PushBack(std::move(value), ::detail::GetAllocator());
 #else
   o.push_back(std::move(value));
 #endif
@@ -6607,7 +6607,7 @@ void JsonSetObject(::detail::json &o) {
 void JsonReserveArray(::detail::json &o, size_t s) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   o.SetArray();
-  o.Reserve(static_cast<rapidjson::SizeType>(s), GetAllocator());
+  o.Reserve(static_cast<rapidjson::SizeType>(s), ::detail::GetAllocator());
 #endif
   (void)(o);
   (void)(s);
@@ -6676,17 +6676,17 @@ static bool ValueToJson(const Value &value, ::detail::json *ret) {
       obj.SetBool(value.Get<bool>());
       break;
     case STRING_TYPE:
-      obj.SetString(value.Get<std::string>().c_str(), GetAllocator());
+      obj.SetString(value.Get<std::string>().c_str(), ::detail::GetAllocator());
       break;
     case ARRAY_TYPE: {
       obj.SetArray();
       obj.Reserve(static_cast<rapidjson::SizeType>(value.ArrayLen()),
-                  GetAllocator());
+                  ::detail::GetAllocator());
       for (unsigned int i = 0; i < value.ArrayLen(); ++i) {
         Value elementValue = value.Get(int(i));
         ::detail::json elementJson;
         if (ValueToJson(value.Get(int(i)), &elementJson))
-          obj.PushBack(std::move(elementJson), GetAllocator());
+          obj.PushBack(std::move(elementJson), ::detail::GetAllocator());
       }
       break;
     }
@@ -6701,8 +6701,8 @@ static bool ValueToJson(const Value &value, ::detail::json *ret) {
       for (auto &it : objMap) {
         ::detail::json elementJson;
         if (ValueToJson(it.second, &elementJson)) {
-          obj.AddMember(::detail::json(it.first.c_str(), GetAllocator()),
-                        std::move(elementJson), GetAllocator());
+          obj.AddMember(::detail::json(it.first.c_str(), ::detail::GetAllocator()),
+                        std::move(elementJson), ::detail::GetAllocator());
         }
       }
       break;

--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -1705,7 +1705,7 @@ class TinyGLTF {
 #endif
 #endif
 
-namespace {
+namespace detail {
 #ifdef TINYGLTF_USE_RAPIDJSON
 
 #ifdef TINYGLTF_USE_RAPIDJSON_CRTALLOCATOR
@@ -1781,7 +1781,7 @@ void JsonParse(JsonDocument &doc, const char *str, size_t length,
   (void)throwExc;
   doc.Parse(str, length);
 #else
-  doc = json::parse(str, str + length, nullptr, throwExc);
+  doc = ::detail::json::parse(str, str + length, nullptr, throwExc);
 #endif
 }
 }  // namespace
@@ -3067,8 +3067,8 @@ bool DecodeDataURI(std::vector<unsigned char> *out, std::string &mime_type,
   return true;
 }
 
-namespace {
-bool GetInt(const json &o, int &val) {
+namespace detail {
+bool GetInt(const ::detail::json &o, int &val) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   if (!o.IsDouble()) {
     if (o.IsInt()) {
@@ -3090,8 +3090,8 @@ bool GetInt(const json &o, int &val) {
 #else
   auto type = o.type();
 
-  if ((type == json::value_t::number_integer) ||
-      (type == json::value_t::number_unsigned)) {
+  if ((type == ::detail::json::value_t::number_integer) ||
+      (type == ::detail::json::value_t::number_unsigned)) {
     val = static_cast<int>(o.get<int64_t>());
     return true;
   }
@@ -3101,7 +3101,7 @@ bool GetInt(const json &o, int &val) {
 }
 
 #ifdef TINYGLTF_USE_RAPIDJSON
-bool GetDouble(const json &o, double &val) {
+bool GetDouble(const ::detail::json &o, double &val) {
   if (o.IsDouble()) {
     val = o.GetDouble();
     return true;
@@ -3111,7 +3111,7 @@ bool GetDouble(const json &o, double &val) {
 }
 #endif
 
-bool GetNumber(const json &o, double &val) {
+bool GetNumber(const ::detail::json &o, double &val) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   if (o.IsNumber()) {
     val = o.GetDouble();
@@ -3129,7 +3129,7 @@ bool GetNumber(const json &o, double &val) {
 #endif
 }
 
-bool GetString(const json &o, std::string &val) {
+bool GetString(const ::detail::json &o, std::string &val) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   if (o.IsString()) {
     val = o.GetString();
@@ -3138,7 +3138,7 @@ bool GetString(const json &o, std::string &val) {
 
   return false;
 #else
-  if (o.type() == json::value_t::string) {
+  if (o.type() == ::detail::json::value_t::string) {
     val = o.get<std::string>();
     return true;
   }
@@ -3147,7 +3147,7 @@ bool GetString(const json &o, std::string &val) {
 #endif
 }
 
-bool IsArray(const json &o) {
+bool IsArray(const ::detail::json &o) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   return o.IsArray();
 #else
@@ -3155,7 +3155,7 @@ bool IsArray(const json &o) {
 #endif
 }
 
-json_const_array_iterator ArrayBegin(const json &o) {
+::detail::json_const_array_iterator ArrayBegin(const ::detail::json &o) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   return o.Begin();
 #else
@@ -3163,7 +3163,7 @@ json_const_array_iterator ArrayBegin(const json &o) {
 #endif
 }
 
-json_const_array_iterator ArrayEnd(const json &o) {
+::detail::json_const_array_iterator ArrayEnd(const ::detail::json &o) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   return o.End();
 #else
@@ -3171,7 +3171,7 @@ json_const_array_iterator ArrayEnd(const json &o) {
 #endif
 }
 
-bool IsObject(const json &o) {
+bool IsObject(const ::detail::json &o) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   return o.IsObject();
 #else
@@ -3179,7 +3179,7 @@ bool IsObject(const json &o) {
 #endif
 }
 
-json_const_iterator ObjectBegin(const json &o) {
+::detail::json_const_iterator ObjectBegin(const ::detail::json &o) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   return o.MemberBegin();
 #else
@@ -3187,7 +3187,7 @@ json_const_iterator ObjectBegin(const json &o) {
 #endif
 }
 
-json_const_iterator ObjectEnd(const json &o) {
+::detail::json_const_iterator ObjectEnd(const ::detail::json &o) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   return o.MemberEnd();
 #else
@@ -3197,7 +3197,7 @@ json_const_iterator ObjectEnd(const json &o) {
 
 // Making this a const char* results in a pointer to a temporary when
 // TINYGLTF_USE_RAPIDJSON is off.
-std::string GetKey(json_const_iterator &it) {
+std::string GetKey(::detail::json_const_iterator &it) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   return it->name.GetString();
 #else
@@ -3205,7 +3205,7 @@ std::string GetKey(json_const_iterator &it) {
 #endif
 }
 
-bool FindMember(const json &o, const char *member, json_const_iterator &it) {
+bool FindMember(const ::detail::json &o, const char *member, ::detail::json_const_iterator &it) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   if (!o.IsObject()) {
     return false;
@@ -3218,7 +3218,7 @@ bool FindMember(const json &o, const char *member, json_const_iterator &it) {
 #endif
 }
 
-const json &GetValue(json_const_iterator &it) {
+const ::detail::json &GetValue(::detail::json_const_iterator &it) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   return it->value;
 #else
@@ -3226,7 +3226,7 @@ const json &GetValue(json_const_iterator &it) {
 #endif
 }
 
-std::string JsonToString(const json &o, int spacing = -1) {
+std::string JsonToString(const ::detail::json &o, int spacing = -1) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   using namespace rapidjson;
   StringBuffer buffer;
@@ -3252,7 +3252,7 @@ std::string JsonToString(const json &o, int spacing = -1) {
 
 }  // namespace
 
-static bool ParseJsonAsValue(Value *ret, const json &o) {
+static bool ParseJsonAsValue(Value *ret, const ::detail::json &o) {
   Value val{};
 #ifdef TINYGLTF_USE_RAPIDJSON
   using rapidjson::Type;
@@ -3263,7 +3263,7 @@ static bool ParseJsonAsValue(Value *ret, const json &o) {
         Value entry;
         ParseJsonAsValue(&entry, it->value);
         if (entry.Type() != NULL_TYPE)
-          value_object.emplace(GetKey(it), std::move(entry));
+          value_object.emplace(detail::GetKey(it), std::move(entry));
       }
       if (value_object.size() > 0) val = Value(std::move(value_object));
     } break;
@@ -3288,7 +3288,7 @@ static bool ParseJsonAsValue(Value *ret, const json &o) {
     case Type::kNumberType:
       if (!o.IsDouble()) {
         int i = 0;
-        GetInt(o, i);
+        detail::GetInt(o, i);
         val = Value(i);
       } else {
         double d = 0.0;
@@ -3302,7 +3302,7 @@ static bool ParseJsonAsValue(Value *ret, const json &o) {
   }
 #else
   switch (o.type()) {
-    case json::value_t::object: {
+    case ::detail::json::value_t::object: {
       Value::Object value_object;
       for (auto it = o.begin(); it != o.end(); it++) {
         Value entry;
@@ -3312,7 +3312,7 @@ static bool ParseJsonAsValue(Value *ret, const json &o) {
       }
       if (value_object.size() > 0) val = Value(std::move(value_object));
     } break;
-    case json::value_t::array: {
+    case ::detail::json::value_t::array: {
       Value::Array value_array;
       value_array.reserve(o.size());
       for (auto it = o.begin(); it != o.end(); it++) {
@@ -3323,22 +3323,22 @@ static bool ParseJsonAsValue(Value *ret, const json &o) {
       }
       if (value_array.size() > 0) val = Value(std::move(value_array));
     } break;
-    case json::value_t::string:
+    case ::detail::json::value_t::string:
       val = Value(o.get<std::string>());
       break;
-    case json::value_t::boolean:
+    case ::detail::json::value_t::boolean:
       val = Value(o.get<bool>());
       break;
-    case json::value_t::number_integer:
-    case json::value_t::number_unsigned:
+    case ::detail::json::value_t::number_integer:
+    case ::detail::json::value_t::number_unsigned:
       val = Value(static_cast<int>(o.get<int64_t>()));
       break;
-    case json::value_t::number_float:
+    case ::detail::json::value_t::number_float:
       val = Value(o.get<double>());
       break;
-    case json::value_t::null:
-    case json::value_t::discarded:
-    case json::value_t::binary:
+    case ::detail::json::value_t::null:
+    case ::detail::json::value_t::discarded:
+    case ::detail::json::value_t::binary:
       // default:
       break;
   }
@@ -3350,21 +3350,21 @@ static bool ParseJsonAsValue(Value *ret, const json &o) {
   return isNotNull;
 }
 
-static bool ParseExtrasProperty(Value *ret, const json &o) {
-  json_const_iterator it;
-  if (!FindMember(o, "extras", it)) {
+static bool ParseExtrasProperty(Value *ret, const ::detail::json &o) {
+  ::detail::json_const_iterator it;
+  if (!detail::FindMember(o, "extras", it)) {
     return false;
   }
 
-  return ParseJsonAsValue(ret, GetValue(it));
+  return ParseJsonAsValue(ret, detail::GetValue(it));
 }
 
-static bool ParseBooleanProperty(bool *ret, std::string *err, const json &o,
+static bool ParseBooleanProperty(bool *ret, std::string *err, const ::detail::json &o,
                                  const std::string &property,
                                  const bool required,
                                  const std::string &parent_node = "") {
-  json_const_iterator it;
-  if (!FindMember(o, property.c_str(), it)) {
+  ::detail::json_const_iterator it;
+  if (!detail::FindMember(o, property.c_str(), it)) {
     if (required) {
       if (err) {
         (*err) += "'" + property + "' property is missing";
@@ -3377,7 +3377,7 @@ static bool ParseBooleanProperty(bool *ret, std::string *err, const json &o,
     return false;
   }
 
-  auto &value = GetValue(it);
+  auto &value = detail::GetValue(it);
 
   bool isBoolean;
   bool boolValue = false;
@@ -3408,12 +3408,12 @@ static bool ParseBooleanProperty(bool *ret, std::string *err, const json &o,
   return true;
 }
 
-static bool ParseIntegerProperty(int *ret, std::string *err, const json &o,
+static bool ParseIntegerProperty(int *ret, std::string *err, const ::detail::json &o,
                                  const std::string &property,
                                  const bool required,
                                  const std::string &parent_node = "") {
-  json_const_iterator it;
-  if (!FindMember(o, property.c_str(), it)) {
+  ::detail::json_const_iterator it;
+  if (!detail::FindMember(o, property.c_str(), it)) {
     if (required) {
       if (err) {
         (*err) += "'" + property + "' property is missing";
@@ -3427,7 +3427,7 @@ static bool ParseIntegerProperty(int *ret, std::string *err, const json &o,
   }
 
   int intValue;
-  bool isInt = GetInt(GetValue(it), intValue);
+  bool isInt = detail::GetInt(detail::GetValue(it), intValue);
   if (!isInt) {
     if (required) {
       if (err) {
@@ -3444,12 +3444,12 @@ static bool ParseIntegerProperty(int *ret, std::string *err, const json &o,
   return true;
 }
 
-static bool ParseUnsignedProperty(size_t *ret, std::string *err, const json &o,
+static bool ParseUnsignedProperty(size_t *ret, std::string *err, const ::detail::json &o,
                                   const std::string &property,
                                   const bool required,
                                   const std::string &parent_node = "") {
-  json_const_iterator it;
-  if (!FindMember(o, property.c_str(), it)) {
+  ::detail::json_const_iterator it;
+  if (!detail::FindMember(o, property.c_str(), it)) {
     if (required) {
       if (err) {
         (*err) += "'" + property + "' property is missing";
@@ -3462,7 +3462,7 @@ static bool ParseUnsignedProperty(size_t *ret, std::string *err, const json &o,
     return false;
   }
 
-  auto &value = GetValue(it);
+  auto &value = detail::GetValue(it);
 
   size_t uValue = 0;
   bool isUValue;
@@ -3497,13 +3497,13 @@ static bool ParseUnsignedProperty(size_t *ret, std::string *err, const json &o,
   return true;
 }
 
-static bool ParseNumberProperty(double *ret, std::string *err, const json &o,
+static bool ParseNumberProperty(double *ret, std::string *err, const ::detail::json &o,
                                 const std::string &property,
                                 const bool required,
                                 const std::string &parent_node = "") {
-  json_const_iterator it;
+  ::detail::json_const_iterator it;
 
-  if (!FindMember(o, property.c_str(), it)) {
+  if (!detail::FindMember(o, property.c_str(), it)) {
     if (required) {
       if (err) {
         (*err) += "'" + property + "' property is missing";
@@ -3517,7 +3517,7 @@ static bool ParseNumberProperty(double *ret, std::string *err, const json &o,
   }
 
   double numberValue;
-  bool isNumber = GetNumber(GetValue(it), numberValue);
+  bool isNumber = detail::GetNumber(detail::GetValue(it), numberValue);
 
   if (!isNumber) {
     if (required) {
@@ -3536,11 +3536,11 @@ static bool ParseNumberProperty(double *ret, std::string *err, const json &o,
 }
 
 static bool ParseNumberArrayProperty(std::vector<double> *ret, std::string *err,
-                                     const json &o, const std::string &property,
+                                     const ::detail::json &o, const std::string &property,
                                      bool required,
                                      const std::string &parent_node = "") {
-  json_const_iterator it;
-  if (!FindMember(o, property.c_str(), it)) {
+  ::detail::json_const_iterator it;
+  if (!detail::FindMember(o, property.c_str(), it)) {
     if (required) {
       if (err) {
         (*err) += "'" + property + "' property is missing";
@@ -3553,7 +3553,7 @@ static bool ParseNumberArrayProperty(std::vector<double> *ret, std::string *err,
     return false;
   }
 
-  if (!IsArray(GetValue(it))) {
+  if (!detail::IsArray(detail::GetValue(it))) {
     if (required) {
       if (err) {
         (*err) += "'" + property + "' property is not an array";
@@ -3567,10 +3567,10 @@ static bool ParseNumberArrayProperty(std::vector<double> *ret, std::string *err,
   }
 
   ret->clear();
-  auto end = ArrayEnd(GetValue(it));
-  for (auto i = ArrayBegin(GetValue(it)); i != end; ++i) {
+  auto end = detail::ArrayEnd(detail::GetValue(it));
+  for (auto i = detail::ArrayBegin(detail::GetValue(it)); i != end; ++i) {
     double numberValue;
-    const bool isNumber = GetNumber(*i, numberValue);
+    const bool isNumber = detail::GetNumber(*i, numberValue);
     if (!isNumber) {
       if (required) {
         if (err) {
@@ -3590,12 +3590,12 @@ static bool ParseNumberArrayProperty(std::vector<double> *ret, std::string *err,
 }
 
 static bool ParseIntegerArrayProperty(std::vector<int> *ret, std::string *err,
-                                      const json &o,
+                                      const ::detail::json &o,
                                       const std::string &property,
                                       bool required,
                                       const std::string &parent_node = "") {
-  json_const_iterator it;
-  if (!FindMember(o, property.c_str(), it)) {
+  ::detail::json_const_iterator it;
+  if (!detail::FindMember(o, property.c_str(), it)) {
     if (required) {
       if (err) {
         (*err) += "'" + property + "' property is missing";
@@ -3608,7 +3608,7 @@ static bool ParseIntegerArrayProperty(std::vector<int> *ret, std::string *err,
     return false;
   }
 
-  if (!IsArray(GetValue(it))) {
+  if (!detail::IsArray(detail::GetValue(it))) {
     if (required) {
       if (err) {
         (*err) += "'" + property + "' property is not an array";
@@ -3622,10 +3622,10 @@ static bool ParseIntegerArrayProperty(std::vector<int> *ret, std::string *err,
   }
 
   ret->clear();
-  auto end = ArrayEnd(GetValue(it));
-  for (auto i = ArrayBegin(GetValue(it)); i != end; ++i) {
+  auto end = detail::ArrayEnd(detail::GetValue(it));
+  for (auto i = detail::ArrayBegin(detail::GetValue(it)); i != end; ++i) {
     int numberValue;
-    bool isNumber = GetInt(*i, numberValue);
+    bool isNumber = detail::GetInt(*i, numberValue);
     if (!isNumber) {
       if (required) {
         if (err) {
@@ -3645,11 +3645,11 @@ static bool ParseIntegerArrayProperty(std::vector<int> *ret, std::string *err,
 }
 
 static bool ParseStringProperty(
-    std::string *ret, std::string *err, const json &o,
+    std::string *ret, std::string *err, const ::detail::json &o,
     const std::string &property, bool required,
     const std::string &parent_node = std::string()) {
-  json_const_iterator it;
-  if (!FindMember(o, property.c_str(), it)) {
+  ::detail::json_const_iterator it;
+  if (!detail::FindMember(o, property.c_str(), it)) {
     if (required) {
       if (err) {
         (*err) += "'" + property + "' property is missing";
@@ -3664,7 +3664,7 @@ static bool ParseStringProperty(
   }
 
   std::string strValue;
-  if (!GetString(GetValue(it), strValue)) {
+  if (!detail::GetString(detail::GetValue(it), strValue)) {
     if (required) {
       if (err) {
         (*err) += "'" + property + "' property is not a string type.\n";
@@ -3681,12 +3681,12 @@ static bool ParseStringProperty(
 }
 
 static bool ParseStringIntegerProperty(std::map<std::string, int> *ret,
-                                       std::string *err, const json &o,
+                                       std::string *err, const ::detail::json &o,
                                        const std::string &property,
                                        bool required,
                                        const std::string &parent = "") {
-  json_const_iterator it;
-  if (!FindMember(o, property.c_str(), it)) {
+  ::detail::json_const_iterator it;
+  if (!detail::FindMember(o, property.c_str(), it)) {
     if (required) {
       if (err) {
         if (!parent.empty()) {
@@ -3700,10 +3700,10 @@ static bool ParseStringIntegerProperty(std::map<std::string, int> *ret,
     return false;
   }
 
-  const json &dict = GetValue(it);
+  const ::detail::json &dict = detail::GetValue(it);
 
   // Make sure we are dealing with an object / dictionary.
-  if (!IsObject(dict)) {
+  if (!detail::IsObject(dict)) {
     if (required) {
       if (err) {
         (*err) += "'" + property + "' property is not an object.\n";
@@ -3714,12 +3714,12 @@ static bool ParseStringIntegerProperty(std::map<std::string, int> *ret,
 
   ret->clear();
 
-  json_const_iterator dictIt(ObjectBegin(dict));
-  json_const_iterator dictItEnd(ObjectEnd(dict));
+  ::detail::json_const_iterator dictIt(detail::ObjectBegin(dict));
+  ::detail::json_const_iterator dictItEnd(detail::ObjectEnd(dict));
 
   for (; dictIt != dictItEnd; ++dictIt) {
     int intVal;
-    if (!GetInt(GetValue(dictIt), intVal)) {
+    if (!detail::GetInt(detail::GetValue(dictIt), intVal)) {
       if (required) {
         if (err) {
           (*err) += "'" + property + "' value is not an integer type.\n";
@@ -3729,16 +3729,16 @@ static bool ParseStringIntegerProperty(std::map<std::string, int> *ret,
     }
 
     // Insert into the list.
-    (*ret)[GetKey(dictIt)] = intVal;
+    (*ret)[detail::GetKey(dictIt)] = intVal;
   }
   return true;
 }
 
 static bool ParseJSONProperty(std::map<std::string, double> *ret,
-                              std::string *err, const json &o,
+                              std::string *err, const ::detail::json &o,
                               const std::string &property, bool required) {
-  json_const_iterator it;
-  if (!FindMember(o, property.c_str(), it)) {
+  ::detail::json_const_iterator it;
+  if (!detail::FindMember(o, property.c_str(), it)) {
     if (required) {
       if (err) {
         (*err) += "'" + property + "' property is missing. \n'";
@@ -3747,9 +3747,9 @@ static bool ParseJSONProperty(std::map<std::string, double> *ret,
     return false;
   }
 
-  const json &obj = GetValue(it);
+  const ::detail::json &obj = detail::GetValue(it);
 
-  if (!IsObject(obj)) {
+  if (!detail::IsObject(obj)) {
     if (required) {
       if (err) {
         (*err) += "'" + property + "' property is not a JSON object.\n";
@@ -3760,19 +3760,19 @@ static bool ParseJSONProperty(std::map<std::string, double> *ret,
 
   ret->clear();
 
-  json_const_iterator it2(ObjectBegin(obj));
-  json_const_iterator itEnd(ObjectEnd(obj));
+  ::detail::json_const_iterator it2(detail::ObjectBegin(obj));
+  ::detail::json_const_iterator itEnd(detail::ObjectEnd(obj));
   for (; it2 != itEnd; ++it2) {
     double numVal;
-    if (GetNumber(GetValue(it2), numVal))
-      ret->emplace(std::string(GetKey(it2)), numVal);
+    if (detail::GetNumber(detail::GetValue(it2), numVal))
+      ret->emplace(std::string(detail::GetKey(it2)), numVal);
   }
 
   return true;
 }
 
 static bool ParseParameterProperty(Parameter *param, std::string *err,
-                                   const json &o, const std::string &prop,
+                                   const ::detail::json &o, const std::string &prop,
                                    bool required) {
   // A parameter value can either be a string or an array of either a boolean or
   // a number. Booleans of any kind aren't supported here. Granted, it
@@ -3805,25 +3805,25 @@ static bool ParseParameterProperty(Parameter *param, std::string *err,
 }
 
 static bool ParseExtensionsProperty(ExtensionMap *ret, std::string *err,
-                                    const json &o) {
+                                    const ::detail::json &o) {
   (void)err;
 
-  json_const_iterator it;
-  if (!FindMember(o, "extensions", it)) {
+  ::detail::json_const_iterator it;
+  if (!detail::FindMember(o, "extensions", it)) {
     return false;
   }
 
-  auto &obj = GetValue(it);
-  if (!IsObject(obj)) {
+  auto &obj = detail::GetValue(it);
+  if (!detail::IsObject(obj)) {
     return false;
   }
   ExtensionMap extensions;
-  json_const_iterator extIt = ObjectBegin(obj);  // it.value().begin();
-  json_const_iterator extEnd = ObjectEnd(obj);
+  ::detail::json_const_iterator extIt = detail::ObjectBegin(obj);  // it.value().begin();
+  ::detail::json_const_iterator extEnd = detail::ObjectEnd(obj);
   for (; extIt != extEnd; ++extIt) {
-    auto &itObj = GetValue(extIt);
-    if (!IsObject(itObj)) continue;
-    std::string key(GetKey(extIt));
+    auto &itObj = detail::GetValue(extIt);
+    if (!detail::IsObject(itObj)) continue;
+    std::string key(detail::GetKey(extIt));
     if (!ParseJsonAsValue(&extensions[key], itObj)) {
       if (!key.empty()) {
         // create empty object so that an extension object is still of type
@@ -3838,7 +3838,7 @@ static bool ParseExtensionsProperty(ExtensionMap *ret, std::string *err,
   return true;
 }
 
-static bool ParseAsset(Asset *asset, std::string *err, const json &o,
+static bool ParseAsset(Asset *asset, std::string *err, const ::detail::json &o,
                        bool store_original_json_for_extras_and_extensions) {
   ParseStringProperty(&asset->version, err, o, "version", true, "Asset");
   ParseStringProperty(&asset->generator, err, o, "generator", false, "Asset");
@@ -3852,15 +3852,15 @@ static bool ParseAsset(Asset *asset, std::string *err, const json &o,
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      json_const_iterator it;
-      if (FindMember(o, "extensions", it)) {
-        asset->extensions_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extensions", it)) {
+        asset->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      json_const_iterator it;
-      if (FindMember(o, "extras", it)) {
-        asset->extras_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extras", it)) {
+        asset->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
   }
@@ -3869,7 +3869,7 @@ static bool ParseAsset(Asset *asset, std::string *err, const json &o,
 }
 
 static bool ParseImage(Image *image, const int image_idx, std::string *err,
-                       std::string *warn, const json &o,
+                       std::string *warn, const ::detail::json &o,
                        bool store_original_json_for_extras_and_extensions,
                        const std::string &basedir, FsCallbacks *fs,
                        const URICallbacks *uri_cb,
@@ -3879,9 +3879,9 @@ static bool ParseImage(Image *image, const int image_idx, std::string *err,
 
   // schema says oneOf [`bufferView`, `uri`]
   // TODO(syoyo): Check the type of each parameters.
-  json_const_iterator it;
-  bool hasBufferView = FindMember(o, "bufferView", it);
-  bool hasURI = FindMember(o, "uri", it);
+  ::detail::json_const_iterator it;
+  bool hasBufferView = detail::FindMember(o, "bufferView", it);
+  bool hasURI = detail::FindMember(o, "uri", it);
 
   ParseStringProperty(&image->name, err, o, "name", false);
 
@@ -3910,15 +3910,15 @@ static bool ParseImage(Image *image, const int image_idx, std::string *err,
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      json_const_iterator eit;
-      if (FindMember(o, "extensions", eit)) {
-        image->extensions_json_string = JsonToString(GetValue(eit));
+      ::detail::json_const_iterator eit;
+      if (detail::FindMember(o, "extensions", eit)) {
+        image->extensions_json_string = detail::JsonToString(detail::GetValue(eit));
       }
     }
     {
-      json_const_iterator eit;
-      if (FindMember(o, "extras", eit)) {
-        image->extras_json_string = JsonToString(GetValue(eit));
+      ::detail::json_const_iterator eit;
+      if (detail::FindMember(o, "extras", eit)) {
+        image->extras_json_string = detail::JsonToString(detail::GetValue(eit));
       }
     }
   }
@@ -4028,7 +4028,7 @@ static bool ParseImage(Image *image, const int image_idx, std::string *err,
                           static_cast<int>(img.size()), load_image_user_data);
 }
 
-static bool ParseTexture(Texture *texture, std::string *err, const json &o,
+static bool ParseTexture(Texture *texture, std::string *err, const ::detail::json &o,
                          bool store_original_json_for_extras_and_extensions,
                          const std::string &basedir) {
   (void)basedir;
@@ -4046,15 +4046,15 @@ static bool ParseTexture(Texture *texture, std::string *err, const json &o,
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      json_const_iterator it;
-      if (FindMember(o, "extensions", it)) {
-        texture->extensions_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extensions", it)) {
+        texture->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      json_const_iterator it;
-      if (FindMember(o, "extras", it)) {
-        texture->extras_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extras", it)) {
+        texture->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
   }
@@ -4065,7 +4065,7 @@ static bool ParseTexture(Texture *texture, std::string *err, const json &o,
 }
 
 static bool ParseTextureInfo(
-    TextureInfo *texinfo, std::string *err, const json &o,
+    TextureInfo *texinfo, std::string *err, const ::detail::json &o,
     bool store_original_json_for_extras_and_extensions) {
   if (texinfo == nullptr) {
     return false;
@@ -4083,15 +4083,15 @@ static bool ParseTextureInfo(
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      json_const_iterator it;
-      if (FindMember(o, "extensions", it)) {
-        texinfo->extensions_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extensions", it)) {
+        texinfo->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      json_const_iterator it;
-      if (FindMember(o, "extras", it)) {
-        texinfo->extras_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extras", it)) {
+        texinfo->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
   }
@@ -4100,7 +4100,7 @@ static bool ParseTextureInfo(
 }
 
 static bool ParseNormalTextureInfo(
-    NormalTextureInfo *texinfo, std::string *err, const json &o,
+    NormalTextureInfo *texinfo, std::string *err, const ::detail::json &o,
     bool store_original_json_for_extras_and_extensions) {
   if (texinfo == nullptr) {
     return false;
@@ -4119,15 +4119,15 @@ static bool ParseNormalTextureInfo(
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      json_const_iterator it;
-      if (FindMember(o, "extensions", it)) {
-        texinfo->extensions_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extensions", it)) {
+        texinfo->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      json_const_iterator it;
-      if (FindMember(o, "extras", it)) {
-        texinfo->extras_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extras", it)) {
+        texinfo->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
   }
@@ -4136,7 +4136,7 @@ static bool ParseNormalTextureInfo(
 }
 
 static bool ParseOcclusionTextureInfo(
-    OcclusionTextureInfo *texinfo, std::string *err, const json &o,
+    OcclusionTextureInfo *texinfo, std::string *err, const ::detail::json &o,
     bool store_original_json_for_extras_and_extensions) {
   if (texinfo == nullptr) {
     return false;
@@ -4155,15 +4155,15 @@ static bool ParseOcclusionTextureInfo(
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      json_const_iterator it;
-      if (FindMember(o, "extensions", it)) {
-        texinfo->extensions_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extensions", it)) {
+        texinfo->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      json_const_iterator it;
-      if (FindMember(o, "extras", it)) {
-        texinfo->extras_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extras", it)) {
+        texinfo->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
   }
@@ -4171,7 +4171,7 @@ static bool ParseOcclusionTextureInfo(
   return true;
 }
 
-static bool ParseBuffer(Buffer *buffer, std::string *err, const json &o,
+static bool ParseBuffer(Buffer *buffer, std::string *err, const ::detail::json &o,
                         bool store_original_json_for_extras_and_extensions,
                         FsCallbacks *fs, const URICallbacks *uri_cb,
                         const std::string &basedir, bool is_binary = false,
@@ -4194,10 +4194,10 @@ static bool ParseBuffer(Buffer *buffer, std::string *err, const json &o,
     }
   }
 
-  json_const_iterator type;
-  if (FindMember(o, "type", type)) {
+  ::detail::json_const_iterator type;
+  if (detail::FindMember(o, "type", type)) {
     std::string typeStr;
-    if (GetString(GetValue(type), typeStr)) {
+    if (detail::GetString(detail::GetValue(type), typeStr)) {
       if (typeStr.compare("arraybuffer") == 0) {
         // buffer.type = "arraybuffer";
       }
@@ -4287,15 +4287,15 @@ static bool ParseBuffer(Buffer *buffer, std::string *err, const json &o,
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      json_const_iterator it;
-      if (FindMember(o, "extensions", it)) {
-        buffer->extensions_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extensions", it)) {
+        buffer->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      json_const_iterator it;
-      if (FindMember(o, "extras", it)) {
-        buffer->extras_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extras", it)) {
+        buffer->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
   }
@@ -4304,7 +4304,7 @@ static bool ParseBuffer(Buffer *buffer, std::string *err, const json &o,
 }
 
 static bool ParseBufferView(
-    BufferView *bufferView, std::string *err, const json &o,
+    BufferView *bufferView, std::string *err, const ::detail::json &o,
     bool store_original_json_for_extras_and_extensions) {
   int buffer = -1;
   if (!ParseIntegerProperty(&buffer, err, o, "buffer", true, "BufferView")) {
@@ -4359,15 +4359,15 @@ static bool ParseBufferView(
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      json_const_iterator it;
-      if (FindMember(o, "extensions", it)) {
-        bufferView->extensions_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extensions", it)) {
+        bufferView->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      json_const_iterator it;
-      if (FindMember(o, "extras", it)) {
-        bufferView->extras_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extras", it)) {
+        bufferView->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
   }
@@ -4380,7 +4380,7 @@ static bool ParseBufferView(
 }
 
 static bool ParseSparseAccessor(Accessor *accessor, std::string *err,
-                                const json &o) {
+                                const ::detail::json &o) {
   accessor->sparse.isSparse = true;
 
   int count = 0;
@@ -4388,20 +4388,20 @@ static bool ParseSparseAccessor(Accessor *accessor, std::string *err,
     return false;
   }
 
-  json_const_iterator indices_iterator;
-  json_const_iterator values_iterator;
-  if (!FindMember(o, "indices", indices_iterator)) {
+  ::detail::json_const_iterator indices_iterator;
+  ::detail::json_const_iterator values_iterator;
+  if (!detail::FindMember(o, "indices", indices_iterator)) {
     (*err) = "the sparse object of this accessor doesn't have indices";
     return false;
   }
 
-  if (!FindMember(o, "values", values_iterator)) {
+  if (!detail::FindMember(o, "values", values_iterator)) {
     (*err) = "the sparse object of this accessor doesn't have values";
     return false;
   }
 
-  const json &indices_obj = GetValue(indices_iterator);
-  const json &values_obj = GetValue(values_iterator);
+  const ::detail::json &indices_obj = detail::GetValue(indices_iterator);
+  const ::detail::json &values_obj = detail::GetValue(values_iterator);
 
   int indices_buffer_view = 0, indices_byte_offset = 0, component_type = 0;
   if (!ParseIntegerProperty(&indices_buffer_view, err, indices_obj,
@@ -4433,7 +4433,7 @@ static bool ParseSparseAccessor(Accessor *accessor, std::string *err,
   return true;
 }
 
-static bool ParseAccessor(Accessor *accessor, std::string *err, const json &o,
+static bool ParseAccessor(Accessor *accessor, std::string *err, const ::detail::json &o,
                           bool store_original_json_for_extras_and_extensions) {
   int bufferView = -1;
   ParseIntegerProperty(&bufferView, err, o, "bufferView", false, "Accessor");
@@ -4518,24 +4518,24 @@ static bool ParseAccessor(Accessor *accessor, std::string *err, const json &o,
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      json_const_iterator it;
-      if (FindMember(o, "extensions", it)) {
-        accessor->extensions_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extensions", it)) {
+        accessor->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      json_const_iterator it;
-      if (FindMember(o, "extras", it)) {
-        accessor->extras_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extras", it)) {
+        accessor->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
   }
 
   // check if accessor has a "sparse" object:
-  json_const_iterator iterator;
-  if (FindMember(o, "sparse", iterator)) {
+  ::detail::json_const_iterator iterator;
+  if (detail::FindMember(o, "sparse", iterator)) {
     // here this accessor has a "sparse" subobject
-    return ParseSparseAccessor(accessor, err, GetValue(iterator));
+    return ParseSparseAccessor(accessor, err, detail::GetValue(iterator));
   }
 
   return true;
@@ -4734,7 +4734,7 @@ static bool ParseDracoExtension(Primitive *primitive, Model *model,
 #endif
 
 static bool ParsePrimitive(Primitive *primitive, Model *model, std::string *err,
-                           const json &o,
+                           const ::detail::json &o,
                            bool store_original_json_for_extras_and_extensions) {
   int material = -1;
   ParseIntegerProperty(&material, err, o, "material", false);
@@ -4753,23 +4753,23 @@ static bool ParsePrimitive(Primitive *primitive, Model *model, std::string *err,
   }
 
   // Look for morph targets
-  json_const_iterator targetsObject;
-  if (FindMember(o, "targets", targetsObject) &&
-      IsArray(GetValue(targetsObject))) {
-    auto targetsObjectEnd = ArrayEnd(GetValue(targetsObject));
-    for (json_const_array_iterator i = ArrayBegin(GetValue(targetsObject));
+  ::detail::json_const_iterator targetsObject;
+  if (detail::FindMember(o, "targets", targetsObject) &&
+      detail::IsArray(detail::GetValue(targetsObject))) {
+    auto targetsObjectEnd = detail::ArrayEnd(detail::GetValue(targetsObject));
+    for (::detail::json_const_array_iterator i = detail::ArrayBegin(detail::GetValue(targetsObject));
          i != targetsObjectEnd; ++i) {
       std::map<std::string, int> targetAttribues;
 
-      const json &dict = *i;
-      if (IsObject(dict)) {
-        json_const_iterator dictIt(ObjectBegin(dict));
-        json_const_iterator dictItEnd(ObjectEnd(dict));
+      const ::detail::json &dict = *i;
+      if (detail::IsObject(dict)) {
+        ::detail::json_const_iterator dictIt(detail::ObjectBegin(dict));
+        ::detail::json_const_iterator dictItEnd(detail::ObjectEnd(dict));
 
         for (; dictIt != dictItEnd; ++dictIt) {
           int iVal;
-          if (GetInt(GetValue(dictIt), iVal))
-            targetAttribues[GetKey(dictIt)] = iVal;
+          if (detail::GetInt(detail::GetValue(dictIt), iVal))
+            targetAttribues[detail::GetKey(dictIt)] = iVal;
         }
         primitive->targets.emplace_back(std::move(targetAttribues));
       }
@@ -4781,15 +4781,15 @@ static bool ParsePrimitive(Primitive *primitive, Model *model, std::string *err,
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      json_const_iterator it;
-      if (FindMember(o, "extensions", it)) {
-        primitive->extensions_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extensions", it)) {
+        primitive->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      json_const_iterator it;
-      if (FindMember(o, "extras", it)) {
-        primitive->extras_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extras", it)) {
+        primitive->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
   }
@@ -4807,16 +4807,16 @@ static bool ParsePrimitive(Primitive *primitive, Model *model, std::string *err,
   return true;
 }
 
-static bool ParseMesh(Mesh *mesh, Model *model, std::string *err, const json &o,
+static bool ParseMesh(Mesh *mesh, Model *model, std::string *err, const ::detail::json &o,
                       bool store_original_json_for_extras_and_extensions) {
   ParseStringProperty(&mesh->name, err, o, "name", false);
 
   mesh->primitives.clear();
-  json_const_iterator primObject;
-  if (FindMember(o, "primitives", primObject) &&
-      IsArray(GetValue(primObject))) {
-    json_const_array_iterator primEnd = ArrayEnd(GetValue(primObject));
-    for (json_const_array_iterator i = ArrayBegin(GetValue(primObject));
+  ::detail::json_const_iterator primObject;
+  if (detail::FindMember(o, "primitives", primObject) &&
+      detail::IsArray(detail::GetValue(primObject))) {
+    ::detail::json_const_array_iterator primEnd = detail::ArrayEnd(detail::GetValue(primObject));
+    for (::detail::json_const_array_iterator i = detail::ArrayBegin(detail::GetValue(primObject));
          i != primEnd; ++i) {
       Primitive primitive;
       if (ParsePrimitive(&primitive, model, err, *i,
@@ -4835,15 +4835,15 @@ static bool ParseMesh(Mesh *mesh, Model *model, std::string *err, const json &o,
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      json_const_iterator it;
-      if (FindMember(o, "extensions", it)) {
-        mesh->extensions_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extensions", it)) {
+        mesh->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      json_const_iterator it;
-      if (FindMember(o, "extras", it)) {
-        mesh->extras_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extras", it)) {
+        mesh->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
   }
@@ -4851,7 +4851,7 @@ static bool ParseMesh(Mesh *mesh, Model *model, std::string *err, const json &o,
   return true;
 }
 
-static bool ParseNode(Node *node, std::string *err, const json &o,
+static bool ParseNode(Node *node, std::string *err, const ::detail::json &o,
                       bool store_original_json_for_extras_and_extensions) {
   ParseStringProperty(&node->name, err, o, "name", false);
 
@@ -4884,15 +4884,15 @@ static bool ParseNode(Node *node, std::string *err, const json &o,
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      json_const_iterator it;
-      if (FindMember(o, "extensions", it)) {
-        node->extensions_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extensions", it)) {
+        node->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      json_const_iterator it;
-      if (FindMember(o, "extras", it)) {
-        node->extras_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extras", it)) {
+        node->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
   }
@@ -4901,7 +4901,7 @@ static bool ParseNode(Node *node, std::string *err, const json &o,
 }
 
 static bool ParsePbrMetallicRoughness(
-    PbrMetallicRoughness *pbr, std::string *err, const json &o,
+    PbrMetallicRoughness *pbr, std::string *err, const ::detail::json &o,
     bool store_original_json_for_extras_and_extensions) {
   if (pbr == nullptr) {
     return false;
@@ -4923,17 +4923,17 @@ static bool ParsePbrMetallicRoughness(
   }
 
   {
-    json_const_iterator it;
-    if (FindMember(o, "baseColorTexture", it)) {
-      ParseTextureInfo(&pbr->baseColorTexture, err, GetValue(it),
+    ::detail::json_const_iterator it;
+    if (detail::FindMember(o, "baseColorTexture", it)) {
+      ParseTextureInfo(&pbr->baseColorTexture, err, detail::GetValue(it),
                        store_original_json_for_extras_and_extensions);
     }
   }
 
   {
-    json_const_iterator it;
-    if (FindMember(o, "metallicRoughnessTexture", it)) {
-      ParseTextureInfo(&pbr->metallicRoughnessTexture, err, GetValue(it),
+    ::detail::json_const_iterator it;
+    if (detail::FindMember(o, "metallicRoughnessTexture", it)) {
+      ParseTextureInfo(&pbr->metallicRoughnessTexture, err, detail::GetValue(it),
                        store_original_json_for_extras_and_extensions);
     }
   }
@@ -4946,15 +4946,15 @@ static bool ParsePbrMetallicRoughness(
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      json_const_iterator it;
-      if (FindMember(o, "extensions", it)) {
-        pbr->extensions_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extensions", it)) {
+        pbr->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      json_const_iterator it;
-      if (FindMember(o, "extras", it)) {
-        pbr->extras_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extras", it)) {
+        pbr->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
   }
@@ -4962,7 +4962,7 @@ static bool ParsePbrMetallicRoughness(
   return true;
 }
 
-static bool ParseMaterial(Material *material, std::string *err, const json &o,
+static bool ParseMaterial(Material *material, std::string *err, const ::detail::json &o,
                           bool store_original_json_for_extras_and_extensions) {
   ParseStringProperty(&material->name, err, o, "name", /* required */ false);
 
@@ -4991,34 +4991,34 @@ static bool ParseMaterial(Material *material, std::string *err, const json &o,
                        /* required */ false);
 
   {
-    json_const_iterator it;
-    if (FindMember(o, "pbrMetallicRoughness", it)) {
+    ::detail::json_const_iterator it;
+    if (detail::FindMember(o, "pbrMetallicRoughness", it)) {
       ParsePbrMetallicRoughness(&material->pbrMetallicRoughness, err,
-                                GetValue(it),
+                                detail::GetValue(it),
                                 store_original_json_for_extras_and_extensions);
     }
   }
 
   {
-    json_const_iterator it;
-    if (FindMember(o, "normalTexture", it)) {
-      ParseNormalTextureInfo(&material->normalTexture, err, GetValue(it),
+    ::detail::json_const_iterator it;
+    if (detail::FindMember(o, "normalTexture", it)) {
+      ParseNormalTextureInfo(&material->normalTexture, err, detail::GetValue(it),
                              store_original_json_for_extras_and_extensions);
     }
   }
 
   {
-    json_const_iterator it;
-    if (FindMember(o, "occlusionTexture", it)) {
-      ParseOcclusionTextureInfo(&material->occlusionTexture, err, GetValue(it),
+    ::detail::json_const_iterator it;
+    if (detail::FindMember(o, "occlusionTexture", it)) {
+      ParseOcclusionTextureInfo(&material->occlusionTexture, err, detail::GetValue(it),
                                 store_original_json_for_extras_and_extensions);
     }
   }
 
   {
-    json_const_iterator it;
-    if (FindMember(o, "emissiveTexture", it)) {
-      ParseTextureInfo(&material->emissiveTexture, err, GetValue(it),
+    ::detail::json_const_iterator it;
+    if (detail::FindMember(o, "emissiveTexture", it)) {
+      ParseTextureInfo(&material->emissiveTexture, err, detail::GetValue(it),
                        store_original_json_for_extras_and_extensions);
     }
   }
@@ -5031,23 +5031,23 @@ static bool ParseMaterial(Material *material, std::string *err, const json &o,
   material->values.clear();
   material->additionalValues.clear();
 
-  json_const_iterator it(ObjectBegin(o));
-  json_const_iterator itEnd(ObjectEnd(o));
+  ::detail::json_const_iterator it(detail::ObjectBegin(o));
+  ::detail::json_const_iterator itEnd(detail::ObjectEnd(o));
 
   for (; it != itEnd; ++it) {
-    std::string key(GetKey(it));
+    std::string key(detail::GetKey(it));
     if (key == "pbrMetallicRoughness") {
-      if (IsObject(GetValue(it))) {
-        const json &values_object = GetValue(it);
+      if (detail::IsObject(detail::GetValue(it))) {
+        const ::detail::json &values_object = detail::GetValue(it);
 
-        json_const_iterator itVal(ObjectBegin(values_object));
-        json_const_iterator itValEnd(ObjectEnd(values_object));
+        ::detail::json_const_iterator itVal(detail::ObjectBegin(values_object));
+        ::detail::json_const_iterator itValEnd(detail::ObjectEnd(values_object));
 
         for (; itVal != itValEnd; ++itVal) {
           Parameter param;
-          if (ParseParameterProperty(&param, err, values_object, GetKey(itVal),
+          if (ParseParameterProperty(&param, err, values_object, detail::GetKey(itVal),
                                      false)) {
-            material->values.emplace(GetKey(itVal), std::move(param));
+            material->values.emplace(detail::GetKey(itVal), std::move(param));
           }
         }
       }
@@ -5071,15 +5071,15 @@ static bool ParseMaterial(Material *material, std::string *err, const json &o,
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      json_const_iterator eit;
-      if (FindMember(o, "extensions", eit)) {
-        material->extensions_json_string = JsonToString(GetValue(eit));
+      ::detail::json_const_iterator eit;
+      if (detail::FindMember(o, "extensions", eit)) {
+        material->extensions_json_string = detail::JsonToString(detail::GetValue(eit));
       }
     }
     {
-      json_const_iterator eit;
-      if (FindMember(o, "extras", eit)) {
-        material->extras_json_string = JsonToString(GetValue(eit));
+      ::detail::json_const_iterator eit;
+      if (detail::FindMember(o, "extras", eit)) {
+        material->extras_json_string = detail::JsonToString(detail::GetValue(eit));
       }
     }
   }
@@ -5088,7 +5088,7 @@ static bool ParseMaterial(Material *material, std::string *err, const json &o,
 }
 
 static bool ParseAnimationChannel(
-    AnimationChannel *channel, std::string *err, const json &o,
+    AnimationChannel *channel, std::string *err, const ::detail::json &o,
     bool store_original_json_for_extras_and_extensions) {
   int samplerIndex = -1;
   int targetIndex = -1;
@@ -5100,9 +5100,9 @@ static bool ParseAnimationChannel(
     return false;
   }
 
-  json_const_iterator targetIt;
-  if (FindMember(o, "target", targetIt) && IsObject(GetValue(targetIt))) {
-    const json &target_object = GetValue(targetIt);
+  ::detail::json_const_iterator targetIt;
+  if (detail::FindMember(o, "target", targetIt) && detail::IsObject(detail::GetValue(targetIt))) {
+    const ::detail::json &target_object = detail::GetValue(targetIt);
 
     ParseIntegerProperty(&targetIndex, err, target_object, "node", false);
 
@@ -5115,9 +5115,9 @@ static bool ParseAnimationChannel(
     }
     ParseExtensionsProperty(&channel->target_extensions, err, target_object);
     if (store_original_json_for_extras_and_extensions) {
-      json_const_iterator it;
-      if (FindMember(target_object, "extensions", it)) {
-        channel->target_extensions_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(target_object, "extensions", it)) {
+        channel->target_extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
   }
@@ -5130,15 +5130,15 @@ static bool ParseAnimationChannel(
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      json_const_iterator it;
-      if (FindMember(o, "extensions", it)) {
-        channel->extensions_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extensions", it)) {
+        channel->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      json_const_iterator it;
-      if (FindMember(o, "extras", it)) {
-        channel->extras_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extras", it)) {
+        channel->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
   }
@@ -5147,14 +5147,14 @@ static bool ParseAnimationChannel(
 }
 
 static bool ParseAnimation(Animation *animation, std::string *err,
-                           const json &o,
+                           const ::detail::json &o,
                            bool store_original_json_for_extras_and_extensions) {
   {
-    json_const_iterator channelsIt;
-    if (FindMember(o, "channels", channelsIt) &&
-        IsArray(GetValue(channelsIt))) {
-      json_const_array_iterator channelEnd = ArrayEnd(GetValue(channelsIt));
-      for (json_const_array_iterator i = ArrayBegin(GetValue(channelsIt));
+    ::detail::json_const_iterator channelsIt;
+    if (detail::FindMember(o, "channels", channelsIt) &&
+        detail::IsArray(detail::GetValue(channelsIt))) {
+      ::detail::json_const_array_iterator channelEnd = detail::ArrayEnd(detail::GetValue(channelsIt));
+      for (::detail::json_const_array_iterator i = detail::ArrayBegin(detail::GetValue(channelsIt));
            i != channelEnd; ++i) {
         AnimationChannel channel;
         if (ParseAnimationChannel(
@@ -5168,15 +5168,15 @@ static bool ParseAnimation(Animation *animation, std::string *err,
   }
 
   {
-    json_const_iterator samplerIt;
-    if (FindMember(o, "samplers", samplerIt) && IsArray(GetValue(samplerIt))) {
-      const json &sampler_array = GetValue(samplerIt);
+    ::detail::json_const_iterator samplerIt;
+    if (detail::FindMember(o, "samplers", samplerIt) && detail::IsArray(detail::GetValue(samplerIt))) {
+      const ::detail::json &sampler_array = detail::GetValue(samplerIt);
 
-      json_const_array_iterator it = ArrayBegin(sampler_array);
-      json_const_array_iterator itEnd = ArrayEnd(sampler_array);
+      ::detail::json_const_array_iterator it = detail::ArrayBegin(sampler_array);
+      ::detail::json_const_array_iterator itEnd = detail::ArrayEnd(sampler_array);
 
       for (; it != itEnd; ++it) {
-        const json &s = *it;
+        const ::detail::json &s = *it;
 
         AnimationSampler sampler;
         int inputIndex = -1;
@@ -5202,15 +5202,15 @@ static bool ParseAnimation(Animation *animation, std::string *err,
 
         if (store_original_json_for_extras_and_extensions) {
           {
-            json_const_iterator eit;
-            if (FindMember(o, "extensions", eit)) {
-              sampler.extensions_json_string = JsonToString(GetValue(eit));
+            ::detail::json_const_iterator eit;
+            if (detail::FindMember(o, "extensions", eit)) {
+              sampler.extensions_json_string = detail::JsonToString(detail::GetValue(eit));
             }
           }
           {
-            json_const_iterator eit;
-            if (FindMember(o, "extras", eit)) {
-              sampler.extras_json_string = JsonToString(GetValue(eit));
+            ::detail::json_const_iterator eit;
+            if (detail::FindMember(o, "extras", eit)) {
+              sampler.extras_json_string = detail::JsonToString(detail::GetValue(eit));
             }
           }
         }
@@ -5227,15 +5227,15 @@ static bool ParseAnimation(Animation *animation, std::string *err,
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      json_const_iterator it;
-      if (FindMember(o, "extensions", it)) {
-        animation->extensions_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extensions", it)) {
+        animation->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      json_const_iterator it;
-      if (FindMember(o, "extras", it)) {
-        animation->extras_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extras", it)) {
+        animation->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
   }
@@ -5243,7 +5243,7 @@ static bool ParseAnimation(Animation *animation, std::string *err,
   return true;
 }
 
-static bool ParseSampler(Sampler *sampler, std::string *err, const json &o,
+static bool ParseSampler(Sampler *sampler, std::string *err, const ::detail::json &o,
                          bool store_original_json_for_extras_and_extensions) {
   ParseStringProperty(&sampler->name, err, o, "name", false);
 
@@ -5273,15 +5273,15 @@ static bool ParseSampler(Sampler *sampler, std::string *err, const json &o,
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      json_const_iterator it;
-      if (FindMember(o, "extensions", it)) {
-        sampler->extensions_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extensions", it)) {
+        sampler->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      json_const_iterator it;
-      if (FindMember(o, "extras", it)) {
-        sampler->extras_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extras", it)) {
+        sampler->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
   }
@@ -5289,7 +5289,7 @@ static bool ParseSampler(Sampler *sampler, std::string *err, const json &o,
   return true;
 }
 
-static bool ParseSkin(Skin *skin, std::string *err, const json &o,
+static bool ParseSkin(Skin *skin, std::string *err, const ::detail::json &o,
                       bool store_original_json_for_extras_and_extensions) {
   ParseStringProperty(&skin->name, err, o, "name", false, "Skin");
 
@@ -5312,15 +5312,15 @@ static bool ParseSkin(Skin *skin, std::string *err, const json &o,
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      json_const_iterator it;
-      if (FindMember(o, "extensions", it)) {
-        skin->extensions_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extensions", it)) {
+        skin->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      json_const_iterator it;
-      if (FindMember(o, "extras", it)) {
-        skin->extras_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extras", it)) {
+        skin->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
   }
@@ -5329,7 +5329,7 @@ static bool ParseSkin(Skin *skin, std::string *err, const json &o,
 }
 
 static bool ParsePerspectiveCamera(
-    PerspectiveCamera *camera, std::string *err, const json &o,
+    PerspectiveCamera *camera, std::string *err, const ::detail::json &o,
     bool store_original_json_for_extras_and_extensions) {
   double yfov = 0.0;
   if (!ParseNumberProperty(&yfov, err, o, "yfov", true, "OrthographicCamera")) {
@@ -5359,15 +5359,15 @@ static bool ParsePerspectiveCamera(
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      json_const_iterator it;
-      if (FindMember(o, "extensions", it)) {
-        camera->extensions_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extensions", it)) {
+        camera->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      json_const_iterator it;
-      if (FindMember(o, "extras", it)) {
-        camera->extras_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extras", it)) {
+        camera->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
   }
@@ -5377,7 +5377,7 @@ static bool ParsePerspectiveCamera(
   return true;
 }
 
-static bool ParseSpotLight(SpotLight *light, std::string *err, const json &o,
+static bool ParseSpotLight(SpotLight *light, std::string *err, const ::detail::json &o,
                            bool store_original_json_for_extras_and_extensions) {
   ParseNumberProperty(&light->innerConeAngle, err, o, "innerConeAngle", false);
   ParseNumberProperty(&light->outerConeAngle, err, o, "outerConeAngle", false);
@@ -5387,15 +5387,15 @@ static bool ParseSpotLight(SpotLight *light, std::string *err, const json &o,
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      json_const_iterator it;
-      if (FindMember(o, "extensions", it)) {
-        light->extensions_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extensions", it)) {
+        light->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      json_const_iterator it;
-      if (FindMember(o, "extras", it)) {
-        light->extras_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extras", it)) {
+        light->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
   }
@@ -5406,7 +5406,7 @@ static bool ParseSpotLight(SpotLight *light, std::string *err, const json &o,
 }
 
 static bool ParseOrthographicCamera(
-    OrthographicCamera *camera, std::string *err, const json &o,
+    OrthographicCamera *camera, std::string *err, const ::detail::json &o,
     bool store_original_json_for_extras_and_extensions) {
   double xmag = 0.0;
   if (!ParseNumberProperty(&xmag, err, o, "xmag", true, "OrthographicCamera")) {
@@ -5434,15 +5434,15 @@ static bool ParseOrthographicCamera(
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      json_const_iterator it;
-      if (FindMember(o, "extensions", it)) {
-        camera->extensions_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extensions", it)) {
+        camera->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      json_const_iterator it;
-      if (FindMember(o, "extras", it)) {
-        camera->extras_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extras", it)) {
+        camera->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
   }
@@ -5457,15 +5457,15 @@ static bool ParseOrthographicCamera(
   return true;
 }
 
-static bool ParseCamera(Camera *camera, std::string *err, const json &o,
+static bool ParseCamera(Camera *camera, std::string *err, const ::detail::json &o,
                         bool store_original_json_for_extras_and_extensions) {
   if (!ParseStringProperty(&camera->type, err, o, "type", true, "Camera")) {
     return false;
   }
 
   if (camera->type.compare("orthographic") == 0) {
-    json_const_iterator orthoIt;
-    if (!FindMember(o, "orthographic", orthoIt)) {
+    ::detail::json_const_iterator orthoIt;
+    if (!detail::FindMember(o, "orthographic", orthoIt)) {
       if (err) {
         std::stringstream ss;
         ss << "Orthographic camera description not found." << std::endl;
@@ -5474,8 +5474,8 @@ static bool ParseCamera(Camera *camera, std::string *err, const json &o,
       return false;
     }
 
-    const json &v = GetValue(orthoIt);
-    if (!IsObject(v)) {
+    const ::detail::json &v = detail::GetValue(orthoIt);
+    if (!detail::IsObject(v)) {
       if (err) {
         std::stringstream ss;
         ss << "\"orthographic\" is not a JSON object." << std::endl;
@@ -5490,8 +5490,8 @@ static bool ParseCamera(Camera *camera, std::string *err, const json &o,
       return false;
     }
   } else if (camera->type.compare("perspective") == 0) {
-    json_const_iterator perspIt;
-    if (!FindMember(o, "perspective", perspIt)) {
+    ::detail::json_const_iterator perspIt;
+    if (!detail::FindMember(o, "perspective", perspIt)) {
       if (err) {
         std::stringstream ss;
         ss << "Perspective camera description not found." << std::endl;
@@ -5500,8 +5500,8 @@ static bool ParseCamera(Camera *camera, std::string *err, const json &o,
       return false;
     }
 
-    const json &v = GetValue(perspIt);
-    if (!IsObject(v)) {
+    const ::detail::json &v = detail::GetValue(perspIt);
+    if (!detail::IsObject(v)) {
       if (err) {
         std::stringstream ss;
         ss << "\"perspective\" is not a JSON object." << std::endl;
@@ -5532,15 +5532,15 @@ static bool ParseCamera(Camera *camera, std::string *err, const json &o,
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      json_const_iterator it;
-      if (FindMember(o, "extensions", it)) {
-        camera->extensions_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extensions", it)) {
+        camera->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      json_const_iterator it;
-      if (FindMember(o, "extras", it)) {
-        camera->extras_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extras", it)) {
+        camera->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
   }
@@ -5548,15 +5548,15 @@ static bool ParseCamera(Camera *camera, std::string *err, const json &o,
   return true;
 }
 
-static bool ParseLight(Light *light, std::string *err, const json &o,
+static bool ParseLight(Light *light, std::string *err, const ::detail::json &o,
                        bool store_original_json_for_extras_and_extensions) {
   if (!ParseStringProperty(&light->type, err, o, "type", true)) {
     return false;
   }
 
   if (light->type == "spot") {
-    json_const_iterator spotIt;
-    if (!FindMember(o, "spot", spotIt)) {
+    ::detail::json_const_iterator spotIt;
+    if (!detail::FindMember(o, "spot", spotIt)) {
       if (err) {
         std::stringstream ss;
         ss << "Spot light description not found." << std::endl;
@@ -5565,8 +5565,8 @@ static bool ParseLight(Light *light, std::string *err, const json &o,
       return false;
     }
 
-    const json &v = GetValue(spotIt);
-    if (!IsObject(v)) {
+    const ::detail::json &v = detail::GetValue(spotIt);
+    if (!detail::IsObject(v)) {
       if (err) {
         std::stringstream ss;
         ss << "\"spot\" is not a JSON object." << std::endl;
@@ -5590,15 +5590,15 @@ static bool ParseLight(Light *light, std::string *err, const json &o,
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      json_const_iterator it;
-      if (FindMember(o, "extensions", it)) {
-        light->extensions_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extensions", it)) {
+        light->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      json_const_iterator it;
-      if (FindMember(o, "extras", it)) {
-        light->extras_json_string = JsonToString(GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extras", it)) {
+        light->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
   }
@@ -5618,13 +5618,13 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
     return false;
   }
 
-  JsonDocument v;
+  ::detail::JsonDocument v;
 
 #if (defined(__cpp_exceptions) || defined(__EXCEPTIONS) || \
      defined(_CPPUNWIND)) &&                               \
     !defined(TINYGLTF_NOEXCEPTION)
   try {
-    JsonParse(v, json_str, json_str_length, true);
+    ::detail::JsonParse(v, json_str, json_str_length, true);
 
   } catch (const std::exception &e) {
     if (err) {
@@ -5634,9 +5634,9 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
   }
 #else
   {
-    JsonParse(v, json_str, json_str_length);
+    ::detail::JsonParse(v, json_str, json_str_length);
 
-    if (!IsObject(v)) {
+    if (!detail::IsObject(v)) {
       // Assume parsing was failed.
       if (err) {
         (*err) = "Failed to parse JSON object\n";
@@ -5646,7 +5646,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
   }
 #endif
 
-  if (!IsObject(v)) {
+  if (!detail::IsObject(v)) {
     // root is not an object.
     if (err) {
       (*err) = "Root element is not a JSON object\n";
@@ -5656,13 +5656,13 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
   {
     bool version_found = false;
-    json_const_iterator it;
-    if (FindMember(v, "asset", it) && IsObject(GetValue(it))) {
-      auto &itObj = GetValue(it);
-      json_const_iterator version_it;
+    ::detail::json_const_iterator it;
+    if (detail::FindMember(v, "asset", it) && detail::IsObject(detail::GetValue(it))) {
+      auto &itObj = detail::GetValue(it);
+      ::detail::json_const_iterator version_it;
       std::string versionStr;
-      if (FindMember(itObj, "version", version_it) &&
-          GetString(GetValue(version_it), versionStr)) {
+      if (detail::FindMember(itObj, "version", version_it) &&
+          detail::GetString(detail::GetValue(version_it), versionStr)) {
         version_found = true;
       }
     }
@@ -5679,9 +5679,9 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
   // scene is not mandatory.
   // FIXME Maybe a better way to handle it than removing the code
 
-  auto IsArrayMemberPresent = [](const json &_v, const char *name) -> bool {
-    json_const_iterator it;
-    return FindMember(_v, name, it) && IsArray(GetValue(it));
+  auto IsArrayMemberPresent = [](const ::detail::json &_v, const char *name) -> bool {
+    ::detail::json_const_iterator it;
+    return detail::FindMember(_v, name, it) && detail::IsArray(detail::GetValue(it));
   };
 
   {
@@ -5746,9 +5746,9 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
   // 1. Parse Asset
   {
-    json_const_iterator it;
-    if (FindMember(v, "asset", it) && IsObject(GetValue(it))) {
-      const json &root = GetValue(it);
+    ::detail::json_const_iterator it;
+    if (detail::FindMember(v, "asset", it) && detail::IsObject(detail::GetValue(it))) {
+      const ::detail::json &root = detail::GetValue(it);
 
       ParseAsset(&model->asset, err, root,
                  store_original_json_for_extras_and_extensions_);
@@ -5756,21 +5756,21 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
   }
 
 #ifdef TINYGLTF_USE_CPP14
-  auto ForEachInArray = [](const json &_v, const char *member,
+  auto ForEachInArray = [](const ::detail::json &_v, const char *member,
                            const auto &cb) -> bool
 #else
   // The std::function<> implementation can be less efficient because it will
   // allocate heap when the size of the captured lambda is above 16 bytes with
   // clang and gcc, but it does not require C++14.
-  auto ForEachInArray = [](const json &_v, const char *member,
-                           const std::function<bool(const json &)> &cb) -> bool
+  auto ForEachInArray = [](const ::detail::json &_v, const char *member,
+                           const std::function<bool(const ::detail::json &)> &cb) -> bool
 #endif
   {
-    json_const_iterator itm;
-    if (FindMember(_v, member, itm) && IsArray(GetValue(itm))) {
-      const json &root = GetValue(itm);
-      auto it = ArrayBegin(root);
-      auto end = ArrayEnd(root);
+    ::detail::json_const_iterator itm;
+    if (detail::FindMember(_v, member, itm) && detail::IsArray(detail::GetValue(itm))) {
+      const ::detail::json &root = detail::GetValue(itm);
+      auto it = detail::ArrayBegin(root);
+      auto end = detail::ArrayEnd(root);
       for (; it != end; ++it) {
         if (!cb(*it)) return false;
       }
@@ -5780,18 +5780,18 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
   // 2. Parse extensionUsed
   {
-    ForEachInArray(v, "extensionsUsed", [&](const json &o) {
+    ForEachInArray(v, "extensionsUsed", [&](const ::detail::json &o) {
       std::string str;
-      GetString(o, str);
+      detail::GetString(o, str);
       model->extensionsUsed.emplace_back(std::move(str));
       return true;
     });
   }
 
   {
-    ForEachInArray(v, "extensionsRequired", [&](const json &o) {
+    ForEachInArray(v, "extensionsRequired", [&](const ::detail::json &o) {
       std::string str;
-      GetString(o, str);
+      detail::GetString(o, str);
       model->extensionsRequired.emplace_back(std::move(str));
       return true;
     });
@@ -5799,8 +5799,8 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
   // 3. Parse Buffer
   {
-    bool success = ForEachInArray(v, "buffers", [&](const json &o) {
-      if (!IsObject(o)) {
+    bool success = ForEachInArray(v, "buffers", [&](const ::detail::json &o) {
+      if (!detail::IsObject(o)) {
         if (err) {
           (*err) += "`buffers' does not contain an JSON object.";
         }
@@ -5823,8 +5823,8 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
   }
   // 4. Parse BufferView
   {
-    bool success = ForEachInArray(v, "bufferViews", [&](const json &o) {
-      if (!IsObject(o)) {
+    bool success = ForEachInArray(v, "bufferViews", [&](const ::detail::json &o) {
+      if (!detail::IsObject(o)) {
         if (err) {
           (*err) += "`bufferViews' does not contain an JSON object.";
         }
@@ -5847,8 +5847,8 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
   // 5. Parse Accessor
   {
-    bool success = ForEachInArray(v, "accessors", [&](const json &o) {
-      if (!IsObject(o)) {
+    bool success = ForEachInArray(v, "accessors", [&](const ::detail::json &o) {
+      if (!detail::IsObject(o)) {
         if (err) {
           (*err) += "`accessors' does not contain an JSON object.";
         }
@@ -5871,8 +5871,8 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
   // 6. Parse Mesh
   {
-    bool success = ForEachInArray(v, "meshes", [&](const json &o) {
-      if (!IsObject(o)) {
+    bool success = ForEachInArray(v, "meshes", [&](const ::detail::json &o) {
+      if (!detail::IsObject(o)) {
         if (err) {
           (*err) += "`meshes' does not contain an JSON object.";
         }
@@ -5954,8 +5954,8 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
   // 7. Parse Node
   {
-    bool success = ForEachInArray(v, "nodes", [&](const json &o) {
-      if (!IsObject(o)) {
+    bool success = ForEachInArray(v, "nodes", [&](const ::detail::json &o) {
+      if (!detail::IsObject(o)) {
         if (err) {
           (*err) += "`nodes' does not contain an JSON object.";
         }
@@ -5978,8 +5978,8 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
   // 8. Parse scenes.
   {
-    bool success = ForEachInArray(v, "scenes", [&](const json &o) {
-      if (!IsObject(o)) {
+    bool success = ForEachInArray(v, "scenes", [&](const ::detail::json &o) {
+      if (!detail::IsObject(o)) {
         if (err) {
           (*err) += "`scenes' does not contain an JSON object.";
         }
@@ -5998,15 +5998,15 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
       if (store_original_json_for_extras_and_extensions_) {
         {
-          json_const_iterator it;
-          if (FindMember(o, "extensions", it)) {
-            scene.extensions_json_string = JsonToString(GetValue(it));
+          ::detail::json_const_iterator it;
+          if (detail::FindMember(o, "extensions", it)) {
+            scene.extensions_json_string = detail::JsonToString(detail::GetValue(it));
           }
         }
         {
-          json_const_iterator it;
-          if (FindMember(o, "extras", it)) {
-            scene.extras_json_string = JsonToString(GetValue(it));
+          ::detail::json_const_iterator it;
+          if (detail::FindMember(o, "extras", it)) {
+            scene.extras_json_string = detail::JsonToString(detail::GetValue(it));
           }
         }
       }
@@ -6022,17 +6022,17 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
   // 9. Parse default scenes.
   {
-    json_const_iterator rootIt;
+    ::detail::json_const_iterator rootIt;
     int iVal;
-    if (FindMember(v, "scene", rootIt) && GetInt(GetValue(rootIt), iVal)) {
+    if (detail::FindMember(v, "scene", rootIt) && detail::GetInt(detail::GetValue(rootIt), iVal)) {
       model->defaultScene = iVal;
     }
   }
 
   // 10. Parse Material
   {
-    bool success = ForEachInArray(v, "materials", [&](const json &o) {
-      if (!IsObject(o)) {
+    bool success = ForEachInArray(v, "materials", [&](const ::detail::json &o) {
+      if (!detail::IsObject(o)) {
         if (err) {
           (*err) += "`materials' does not contain an JSON object.";
         }
@@ -6070,8 +6070,8 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
   {
     int idx = 0;
-    bool success = ForEachInArray(v, "images", [&](const json &o) {
-      if (!IsObject(o)) {
+    bool success = ForEachInArray(v, "images", [&](const ::detail::json &o) {
+      if (!detail::IsObject(o)) {
         if (err) {
           (*err) += "image[" + std::to_string(idx) + "] is not a JSON object.";
         }
@@ -6137,8 +6137,8 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
   // 12. Parse Texture
   {
-    bool success = ForEachInArray(v, "textures", [&](const json &o) {
-      if (!IsObject(o)) {
+    bool success = ForEachInArray(v, "textures", [&](const ::detail::json &o) {
+      if (!detail::IsObject(o)) {
         if (err) {
           (*err) += "`textures' does not contain an JSON object.";
         }
@@ -6162,8 +6162,8 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
   // 13. Parse Animation
   {
-    bool success = ForEachInArray(v, "animations", [&](const json &o) {
-      if (!IsObject(o)) {
+    bool success = ForEachInArray(v, "animations", [&](const ::detail::json &o) {
+      if (!detail::IsObject(o)) {
         if (err) {
           (*err) += "`animations' does not contain an JSON object.";
         }
@@ -6186,8 +6186,8 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
   // 14. Parse Skin
   {
-    bool success = ForEachInArray(v, "skins", [&](const json &o) {
-      if (!IsObject(o)) {
+    bool success = ForEachInArray(v, "skins", [&](const ::detail::json &o) {
+      if (!detail::IsObject(o)) {
         if (err) {
           (*err) += "`skins' does not contain an JSON object.";
         }
@@ -6210,8 +6210,8 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
   // 15. Parse Sampler
   {
-    bool success = ForEachInArray(v, "samplers", [&](const json &o) {
-      if (!IsObject(o)) {
+    bool success = ForEachInArray(v, "samplers", [&](const ::detail::json &o) {
+      if (!detail::IsObject(o)) {
         if (err) {
           (*err) += "`samplers' does not contain an JSON object.";
         }
@@ -6234,8 +6234,8 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
   // 16. Parse Camera
   {
-    bool success = ForEachInArray(v, "cameras", [&](const json &o) {
-      if (!IsObject(o)) {
+    bool success = ForEachInArray(v, "cameras", [&](const ::detail::json &o) {
+      if (!detail::IsObject(o)) {
         if (err) {
           (*err) += "`cameras' does not contain an JSON object.";
         }
@@ -6261,26 +6261,26 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
   // 18. Specific extension implementations
   {
-    json_const_iterator rootIt;
-    if (FindMember(v, "extensions", rootIt) && IsObject(GetValue(rootIt))) {
-      const json &root = GetValue(rootIt);
+    ::detail::json_const_iterator rootIt;
+    if (detail::FindMember(v, "extensions", rootIt) && detail::IsObject(detail::GetValue(rootIt))) {
+      const ::detail::json &root = detail::GetValue(rootIt);
 
-      json_const_iterator it(ObjectBegin(root));
-      json_const_iterator itEnd(ObjectEnd(root));
+      ::detail::json_const_iterator it(detail::ObjectBegin(root));
+      ::detail::json_const_iterator itEnd(detail::ObjectEnd(root));
       for (; it != itEnd; ++it) {
         // parse KHR_lights_punctual extension
-        std::string key(GetKey(it));
-        if ((key == "KHR_lights_punctual") && IsObject(GetValue(it))) {
-          const json &object = GetValue(it);
-          json_const_iterator itLight;
-          if (FindMember(object, "lights", itLight)) {
-            const json &lights = GetValue(itLight);
-            if (!IsArray(lights)) {
+        std::string key(detail::GetKey(it));
+        if ((key == "KHR_lights_punctual") && detail::IsObject(detail::GetValue(it))) {
+          const ::detail::json &object = detail::GetValue(it);
+          ::detail::json_const_iterator itLight;
+          if (detail::FindMember(object, "lights", itLight)) {
+            const ::detail::json &lights = detail::GetValue(itLight);
+            if (!detail::IsArray(lights)) {
               continue;
             }
 
-            auto arrayIt(ArrayBegin(lights));
-            auto arrayItEnd(ArrayEnd(lights));
+            auto arrayIt(detail::ArrayBegin(lights));
+            auto arrayItEnd(detail::ArrayEnd(lights));
             for (; arrayIt != arrayItEnd; ++arrayIt) {
               Light light;
               if (!ParseLight(&light, err, *arrayIt,
@@ -6299,8 +6299,8 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
   ParseExtrasProperty(&model->extras, v);
 
   if (store_original_json_for_extras_and_extensions_) {
-    model->extras_json_string = JsonToString(v["extras"]);
-    model->extensions_json_string = JsonToString(v["extensions"]);
+    model->extras_json_string = detail::JsonToString(v["extras"]);
+    model->extensions_json_string = detail::JsonToString(v["extensions"]);
   }
 
   return true;
@@ -6552,16 +6552,16 @@ bool TinyGLTF::LoadBinaryFromFile(Model *model, std::string *err,
 ///////////////////////
 // GLTF Serialization
 ///////////////////////
-namespace {
-json JsonFromString(const char *s) {
+namespace detail {
+::detail::json JsonFromString(const char *s) {
 #ifdef TINYGLTF_USE_RAPIDJSON
-  return json(s, GetAllocator());
+  return ::detail::json(s, GetAllocator());
 #else
-  return json(s);
+  return ::detail::json(s);
 #endif
 }
 
-void JsonAssign(json &dest, const json &src) {
+void JsonAssign(::detail::json &dest, const ::detail::json &src) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   dest.CopyFrom(src, GetAllocator());
 #else
@@ -6569,7 +6569,7 @@ void JsonAssign(json &dest, const json &src) {
 #endif
 }
 
-void JsonAddMember(json &o, const char *key, json &&value) {
+void JsonAddMember(::detail::json &o, const char *key, ::detail::json &&value) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   if (!o.IsObject()) {
     o.SetObject();
@@ -6580,7 +6580,7 @@ void JsonAddMember(json &o, const char *key, json &&value) {
 #endif
 }
 
-void JsonPushBack(json &o, json &&value) {
+void JsonPushBack(::detail::json &o, ::detail::json &&value) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   o.PushBack(std::move(value), GetAllocator());
 #else
@@ -6588,7 +6588,7 @@ void JsonPushBack(json &o, json &&value) {
 #endif
 }
 
-bool JsonIsNull(const json &o) {
+bool JsonIsNull(const ::detail::json &o) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   return o.IsNull();
 #else
@@ -6596,7 +6596,7 @@ bool JsonIsNull(const json &o) {
 #endif
 }
 
-void JsonSetObject(json &o) {
+void JsonSetObject(::detail::json &o) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   o.SetObject();
 #else
@@ -6604,7 +6604,7 @@ void JsonSetObject(json &o) {
 #endif
 }
 
-void JsonReserveArray(json &o, size_t s) {
+void JsonReserveArray(::detail::json &o, size_t s) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   o.SetArray();
   o.Reserve(static_cast<rapidjson::SizeType>(s), GetAllocator());
@@ -6614,56 +6614,56 @@ void JsonReserveArray(json &o, size_t s) {
 }
 }  // namespace
 
-// typedef std::pair<std::string, json> json_object_pair;
+// typedef std::pair<std::string, ::detail::json> json_object_pair;
 
 template <typename T>
 static void SerializeNumberProperty(const std::string &key, T number,
-                                    json &obj) {
+                                    ::detail::json &obj) {
   // obj.insert(
-  //    json_object_pair(key, json(static_cast<double>(number))));
+  //    json_object_pair(key, ::detail::json(static_cast<double>(number))));
   // obj[key] = static_cast<double>(number);
-  JsonAddMember(obj, key.c_str(), json(number));
+  detail::JsonAddMember(obj, key.c_str(), ::detail::json(number));
 }
 
 #ifdef TINYGLTF_USE_RAPIDJSON
 template <>
-void SerializeNumberProperty(const std::string &key, size_t number, json &obj) {
-  JsonAddMember(obj, key.c_str(), json(static_cast<uint64_t>(number)));
+void SerializeNumberProperty(const std::string &key, size_t number, ::detail::json &obj) {
+  detail::JsonAddMember(obj, key.c_str(), ::detail::json(static_cast<uint64_t>(number)));
 }
 #endif
 
 template <typename T>
 static void SerializeNumberArrayProperty(const std::string &key,
                                          const std::vector<T> &value,
-                                         json &obj) {
+                                         ::detail::json &obj) {
   if (value.empty()) return;
 
-  json ary;
-  JsonReserveArray(ary, value.size());
+  ::detail::json ary;
+  detail::JsonReserveArray(ary, value.size());
   for (const auto &s : value) {
-    JsonPushBack(ary, json(s));
+    detail::JsonPushBack(ary, ::detail::json(s));
   }
-  JsonAddMember(obj, key.c_str(), std::move(ary));
+  detail::JsonAddMember(obj, key.c_str(), std::move(ary));
 }
 
 static void SerializeStringProperty(const std::string &key,
-                                    const std::string &value, json &obj) {
-  JsonAddMember(obj, key.c_str(), JsonFromString(value.c_str()));
+                                    const std::string &value, ::detail::json &obj) {
+  detail::JsonAddMember(obj, key.c_str(), detail::JsonFromString(value.c_str()));
 }
 
 static void SerializeStringArrayProperty(const std::string &key,
                                          const std::vector<std::string> &value,
-                                         json &obj) {
-  json ary;
-  JsonReserveArray(ary, value.size());
+                                         ::detail::json &obj) {
+  ::detail::json ary;
+  detail::JsonReserveArray(ary, value.size());
   for (auto &s : value) {
-    JsonPushBack(ary, JsonFromString(s.c_str()));
+    detail::JsonPushBack(ary, detail::JsonFromString(s.c_str()));
   }
-  JsonAddMember(obj, key.c_str(), std::move(ary));
+  detail::JsonAddMember(obj, key.c_str(), std::move(ary));
 }
 
-static bool ValueToJson(const Value &value, json *ret) {
-  json obj;
+static bool ValueToJson(const Value &value, ::detail::json *ret) {
+  ::detail::json obj;
 #ifdef TINYGLTF_USE_RAPIDJSON
   switch (value.Type()) {
     case REAL_TYPE:
@@ -6684,7 +6684,7 @@ static bool ValueToJson(const Value &value, json *ret) {
                   GetAllocator());
       for (unsigned int i = 0; i < value.ArrayLen(); ++i) {
         Value elementValue = value.Get(int(i));
-        json elementJson;
+        ::detail::json elementJson;
         if (ValueToJson(value.Get(int(i)), &elementJson))
           obj.PushBack(std::move(elementJson), GetAllocator());
       }
@@ -6692,16 +6692,16 @@ static bool ValueToJson(const Value &value, json *ret) {
     }
     case BINARY_TYPE:
       // TODO
-      // obj = json(value.Get<std::vector<unsigned char>>());
+      // obj = ::detail::json(value.Get<std::vector<unsigned char>>());
       return false;
       break;
     case OBJECT_TYPE: {
       obj.SetObject();
       Value::Object objMap = value.Get<Value::Object>();
       for (auto &it : objMap) {
-        json elementJson;
+        ::detail::json elementJson;
         if (ValueToJson(it.second, &elementJson)) {
-          obj.AddMember(json(it.first.c_str(), GetAllocator()),
+          obj.AddMember(::detail::json(it.first.c_str(), GetAllocator()),
                         std::move(elementJson), GetAllocator());
         }
       }
@@ -6714,21 +6714,21 @@ static bool ValueToJson(const Value &value, json *ret) {
 #else
   switch (value.Type()) {
     case REAL_TYPE:
-      obj = json(value.Get<double>());
+      obj = ::detail::json(value.Get<double>());
       break;
     case INT_TYPE:
-      obj = json(value.Get<int>());
+      obj = ::detail::json(value.Get<int>());
       break;
     case BOOL_TYPE:
-      obj = json(value.Get<bool>());
+      obj = ::detail::json(value.Get<bool>());
       break;
     case STRING_TYPE:
-      obj = json(value.Get<std::string>());
+      obj = ::detail::json(value.Get<std::string>());
       break;
     case ARRAY_TYPE: {
       for (unsigned int i = 0; i < value.ArrayLen(); ++i) {
         Value elementValue = value.Get(int(i));
-        json elementJson;
+        ::detail::json elementJson;
         if (ValueToJson(value.Get(int(i)), &elementJson))
           obj.push_back(elementJson);
       }
@@ -6742,7 +6742,7 @@ static bool ValueToJson(const Value &value, json *ret) {
     case OBJECT_TYPE: {
       Value::Object objMap = value.Get<Value::Object>();
       for (auto &it : objMap) {
-        json elementJson;
+        ::detail::json elementJson;
         if (ValueToJson(it.second, &elementJson)) obj[it.first] = elementJson;
       }
       break;
@@ -6757,15 +6757,15 @@ static bool ValueToJson(const Value &value, json *ret) {
 }
 
 static void SerializeValue(const std::string &key, const Value &value,
-                           json &obj) {
-  json ret;
+                           ::detail::json &obj) {
+  ::detail::json ret;
   if (ValueToJson(value, &ret)) {
-    JsonAddMember(obj, key.c_str(), std::move(ret));
+    detail::JsonAddMember(obj, key.c_str(), std::move(ret));
   }
 }
 
 static void SerializeGltfBufferData(const std::vector<unsigned char> &data,
-                                    json &o) {
+                                    ::detail::json &o) {
   std::string header = "data:application/octet-stream;base64,";
   if (data.size() > 0) {
     std::string encodedData =
@@ -6811,14 +6811,14 @@ static bool SerializeGltfBufferData(const std::vector<unsigned char> &data,
 }
 
 #if 0  // FIXME(syoyo): not used. will be removed in the future release.
-static void SerializeParameterMap(ParameterMap &param, json &o) {
+static void SerializeParameterMap(ParameterMap &param, ::detail::json &o) {
   for (ParameterMap::iterator paramIt = param.begin(); paramIt != param.end();
        ++paramIt) {
     if (paramIt->second.number_array.size()) {
       SerializeNumberArrayProperty<double>(paramIt->first,
                                            paramIt->second.number_array, o);
     } else if (paramIt->second.json_double_value.size()) {
-      json json_double_value;
+      ::detail::json json_double_value;
       for (std::map<std::string, double>::iterator it =
                paramIt->second.json_double_value.begin();
            it != paramIt->second.json_double_value.end(); ++it) {
@@ -6841,33 +6841,33 @@ static void SerializeParameterMap(ParameterMap &param, json &o) {
 }
 #endif
 
-static void SerializeExtensionMap(const ExtensionMap &extensions, json &o) {
+static void SerializeExtensionMap(const ExtensionMap &extensions, ::detail::json &o) {
   if (!extensions.size()) return;
 
-  json extMap;
+  ::detail::json extMap;
   for (ExtensionMap::const_iterator extIt = extensions.begin();
        extIt != extensions.end(); ++extIt) {
     // Allow an empty object for extension(#97)
-    json ret;
+    ::detail::json ret;
     bool isNull = true;
     if (ValueToJson(extIt->second, &ret)) {
-      isNull = JsonIsNull(ret);
-      JsonAddMember(extMap, extIt->first.c_str(), std::move(ret));
+      isNull = detail::JsonIsNull(ret);
+      detail::JsonAddMember(extMap, extIt->first.c_str(), std::move(ret));
     }
     if (isNull) {
       if (!(extIt->first.empty())) {  // name should not be empty, but for sure
         // create empty object so that an extension name is still included in
         // json.
-        json empty;
-        JsonSetObject(empty);
-        JsonAddMember(extMap, extIt->first.c_str(), std::move(empty));
+        ::detail::json empty;
+        detail::JsonSetObject(empty);
+        detail::JsonAddMember(extMap, extIt->first.c_str(), std::move(empty));
       }
     }
   }
-  JsonAddMember(o, "extensions", std::move(extMap));
+  detail::JsonAddMember(o, "extensions", std::move(extMap));
 }
 
-static void SerializeGltfAccessor(const Accessor &accessor, json &o) {
+static void SerializeGltfAccessor(const Accessor &accessor, ::detail::json &o) {
   if (accessor.bufferView >= 0)
     SerializeNumberProperty<int>("bufferView", accessor.bufferView, o);
 
@@ -6940,30 +6940,30 @@ static void SerializeGltfAccessor(const Accessor &accessor, json &o) {
   // sparse
   if (accessor.sparse.isSparse)
   {
-      json sparse;
+      ::detail::json sparse;
       SerializeNumberProperty<int>("count", accessor.sparse.count, sparse);
       {
-          json indices;
+          ::detail::json indices;
           SerializeNumberProperty<int>("bufferView", accessor.sparse.indices.bufferView, indices);
           SerializeNumberProperty<int>("byteOffset", accessor.sparse.indices.byteOffset, indices);
           SerializeNumberProperty<int>("componentType", accessor.sparse.indices.componentType, indices);
-          JsonAddMember(sparse, "indices", std::move(indices));
+          detail::JsonAddMember(sparse, "indices", std::move(indices));
       }
       {
-          json values;
+          ::detail::json values;
           SerializeNumberProperty<int>("bufferView", accessor.sparse.values.bufferView, values);
           SerializeNumberProperty<int>("byteOffset", accessor.sparse.values.byteOffset, values);
-          JsonAddMember(sparse, "values", std::move(values));
+          detail::JsonAddMember(sparse, "values", std::move(values));
       }
-      JsonAddMember(o, "sparse", std::move(sparse));
+      detail::JsonAddMember(o, "sparse", std::move(sparse));
   }
 }
 
 static void SerializeGltfAnimationChannel(const AnimationChannel &channel,
-                                          json &o) {
+                                          ::detail::json &o) {
   SerializeNumberProperty("sampler", channel.sampler, o);
   {
-    json target;
+    ::detail::json target;
 
     if (channel.target_node > 0) {
       SerializeNumberProperty("node", channel.target_node, target);
@@ -6973,7 +6973,7 @@ static void SerializeGltfAnimationChannel(const AnimationChannel &channel,
 
     SerializeExtensionMap(channel.target_extensions, target);
 
-    JsonAddMember(o, "target", std::move(target));
+    detail::JsonAddMember(o, "target", std::move(target));
   }
 
   if (channel.extras.Type() != NULL_TYPE) {
@@ -6984,7 +6984,7 @@ static void SerializeGltfAnimationChannel(const AnimationChannel &channel,
 }
 
 static void SerializeGltfAnimationSampler(const AnimationSampler &sampler,
-                                          json &o) {
+                                          ::detail::json &o) {
   SerializeNumberProperty("input", sampler.input, o);
   SerializeNumberProperty("output", sampler.output, o);
   SerializeStringProperty("interpolation", sampler.interpolation, o);
@@ -6994,33 +6994,33 @@ static void SerializeGltfAnimationSampler(const AnimationSampler &sampler,
   }
 }
 
-static void SerializeGltfAnimation(const Animation &animation, json &o) {
+static void SerializeGltfAnimation(const Animation &animation, ::detail::json &o) {
   if (!animation.name.empty())
     SerializeStringProperty("name", animation.name, o);
 
   {
-    json channels;
-    JsonReserveArray(channels, animation.channels.size());
+    ::detail::json channels;
+    detail::JsonReserveArray(channels, animation.channels.size());
     for (unsigned int i = 0; i < animation.channels.size(); ++i) {
-      json channel;
+      ::detail::json channel;
       AnimationChannel gltfChannel = animation.channels[i];
       SerializeGltfAnimationChannel(gltfChannel, channel);
-      JsonPushBack(channels, std::move(channel));
+      detail::JsonPushBack(channels, std::move(channel));
     }
 
-    JsonAddMember(o, "channels", std::move(channels));
+    detail::JsonAddMember(o, "channels", std::move(channels));
   }
 
   {
-    json samplers;
-    JsonReserveArray(samplers, animation.samplers.size());
+    ::detail::json samplers;
+    detail::JsonReserveArray(samplers, animation.samplers.size());
     for (unsigned int i = 0; i < animation.samplers.size(); ++i) {
-      json sampler;
+      ::detail::json sampler;
       AnimationSampler gltfSampler = animation.samplers[i];
       SerializeGltfAnimationSampler(gltfSampler, sampler);
-      JsonPushBack(samplers, std::move(sampler));
+      detail::JsonPushBack(samplers, std::move(sampler));
     }
-    JsonAddMember(o, "samplers", std::move(samplers));
+    detail::JsonAddMember(o, "samplers", std::move(samplers));
   }
 
   if (animation.extras.Type() != NULL_TYPE) {
@@ -7030,7 +7030,7 @@ static void SerializeGltfAnimation(const Animation &animation, json &o) {
   SerializeExtensionMap(animation.extensions, o);
 }
 
-static void SerializeGltfAsset(const Asset &asset, json &o) {
+static void SerializeGltfAsset(const Asset &asset, ::detail::json &o) {
   if (!asset.generator.empty()) {
     SerializeStringProperty("generator", asset.generator, o);
   }
@@ -7056,7 +7056,7 @@ static void SerializeGltfAsset(const Asset &asset, json &o) {
   SerializeExtensionMap(asset.extensions, o);
 }
 
-static void SerializeGltfBufferBin(const Buffer &buffer, json &o,
+static void SerializeGltfBufferBin(const Buffer &buffer, ::detail::json &o,
                                    std::vector<unsigned char> &binBuffer) {
   SerializeNumberProperty("byteLength", buffer.data.size(), o);
   binBuffer = buffer.data;
@@ -7068,7 +7068,7 @@ static void SerializeGltfBufferBin(const Buffer &buffer, json &o,
   }
 }
 
-static void SerializeGltfBuffer(const Buffer &buffer, json &o) {
+static void SerializeGltfBuffer(const Buffer &buffer, ::detail::json &o) {
   SerializeNumberProperty("byteLength", buffer.data.size(), o);
   SerializeGltfBufferData(buffer.data, o);
 
@@ -7079,7 +7079,7 @@ static void SerializeGltfBuffer(const Buffer &buffer, json &o) {
   }
 }
 
-static bool SerializeGltfBuffer(const Buffer &buffer, json &o,
+static bool SerializeGltfBuffer(const Buffer &buffer, ::detail::json &o,
                                 const std::string &binFilename,
                                 const std::string &binUri) {
   if (!SerializeGltfBufferData(buffer.data, binFilename)) return false;
@@ -7094,7 +7094,7 @@ static bool SerializeGltfBuffer(const Buffer &buffer, json &o,
   return true;
 }
 
-static void SerializeGltfBufferView(const BufferView &bufferView, json &o) {
+static void SerializeGltfBufferView(const BufferView &bufferView, ::detail::json &o) {
   SerializeNumberProperty("buffer", bufferView.buffer, o);
   SerializeNumberProperty<size_t>("byteLength", bufferView.byteLength, o);
 
@@ -7121,7 +7121,7 @@ static void SerializeGltfBufferView(const BufferView &bufferView, json &o) {
 }
 
 static void SerializeGltfImage(const Image &image, const std::string &uri,
-                               json &o) {
+                               ::detail::json &o) {
   // From 2.7.0, we look for `uri` parameter, not `Image.uri`
   // if uri is empty, the mimeType and bufferview should be set
   if (uri.empty()) {
@@ -7142,7 +7142,7 @@ static void SerializeGltfImage(const Image &image, const std::string &uri,
   SerializeExtensionMap(image.extensions, o);
 }
 
-static void SerializeGltfTextureInfo(const TextureInfo &texinfo, json &o) {
+static void SerializeGltfTextureInfo(const TextureInfo &texinfo, ::detail::json &o) {
   SerializeNumberProperty("index", texinfo.index, o);
 
   if (texinfo.texCoord != 0) {
@@ -7157,7 +7157,7 @@ static void SerializeGltfTextureInfo(const TextureInfo &texinfo, json &o) {
 }
 
 static void SerializeGltfNormalTextureInfo(const NormalTextureInfo &texinfo,
-                                           json &o) {
+                                           ::detail::json &o) {
   SerializeNumberProperty("index", texinfo.index, o);
 
   if (texinfo.texCoord != 0) {
@@ -7176,7 +7176,7 @@ static void SerializeGltfNormalTextureInfo(const NormalTextureInfo &texinfo,
 }
 
 static void SerializeGltfOcclusionTextureInfo(
-    const OcclusionTextureInfo &texinfo, json &o) {
+    const OcclusionTextureInfo &texinfo, ::detail::json &o) {
   SerializeNumberProperty("index", texinfo.index, o);
 
   if (texinfo.texCoord != 0) {
@@ -7195,7 +7195,7 @@ static void SerializeGltfOcclusionTextureInfo(
 }
 
 static void SerializeGltfPbrMetallicRoughness(const PbrMetallicRoughness &pbr,
-                                              json &o) {
+                                              ::detail::json &o) {
   std::vector<double> default_baseColorFactor = {1.0, 1.0, 1.0, 1.0};
   if (!Equals(pbr.baseColorFactor, default_baseColorFactor)) {
     SerializeNumberArrayProperty<double>("baseColorFactor", pbr.baseColorFactor,
@@ -7211,15 +7211,15 @@ static void SerializeGltfPbrMetallicRoughness(const PbrMetallicRoughness &pbr,
   }
 
   if (pbr.baseColorTexture.index > -1) {
-    json texinfo;
+    ::detail::json texinfo;
     SerializeGltfTextureInfo(pbr.baseColorTexture, texinfo);
-    JsonAddMember(o, "baseColorTexture", std::move(texinfo));
+    detail::JsonAddMember(o, "baseColorTexture", std::move(texinfo));
   }
 
   if (pbr.metallicRoughnessTexture.index > -1) {
-    json texinfo;
+    ::detail::json texinfo;
     SerializeGltfTextureInfo(pbr.metallicRoughnessTexture, texinfo);
-    JsonAddMember(o, "metallicRoughnessTexture", std::move(texinfo));
+    detail::JsonAddMember(o, "metallicRoughnessTexture", std::move(texinfo));
   }
 
   SerializeExtensionMap(pbr.extensions, o);
@@ -7229,7 +7229,7 @@ static void SerializeGltfPbrMetallicRoughness(const PbrMetallicRoughness &pbr,
   }
 }
 
-static void SerializeGltfMaterial(const Material &material, json &o) {
+static void SerializeGltfMaterial(const Material &material, ::detail::json &o) {
   if (material.name.size()) {
     SerializeStringProperty("name", material.name, o);
   }
@@ -7245,24 +7245,24 @@ static void SerializeGltfMaterial(const Material &material, json &o) {
   }
 
   if (material.doubleSided != false)
-    JsonAddMember(o, "doubleSided", json(material.doubleSided));
+    detail::JsonAddMember(o, "doubleSided", ::detail::json(material.doubleSided));
 
   if (material.normalTexture.index > -1) {
-    json texinfo;
+    ::detail::json texinfo;
     SerializeGltfNormalTextureInfo(material.normalTexture, texinfo);
-    JsonAddMember(o, "normalTexture", std::move(texinfo));
+    detail::JsonAddMember(o, "normalTexture", std::move(texinfo));
   }
 
   if (material.occlusionTexture.index > -1) {
-    json texinfo;
+    ::detail::json texinfo;
     SerializeGltfOcclusionTextureInfo(material.occlusionTexture, texinfo);
-    JsonAddMember(o, "occlusionTexture", std::move(texinfo));
+    detail::JsonAddMember(o, "occlusionTexture", std::move(texinfo));
   }
 
   if (material.emissiveTexture.index > -1) {
-    json texinfo;
+    ::detail::json texinfo;
     SerializeGltfTextureInfo(material.emissiveTexture, texinfo);
-    JsonAddMember(o, "emissiveTexture", std::move(texinfo));
+    detail::JsonAddMember(o, "emissiveTexture", std::move(texinfo));
   }
 
   std::vector<double> default_emissiveFactor = {0.0, 0.0, 0.0};
@@ -7272,7 +7272,7 @@ static void SerializeGltfMaterial(const Material &material, json &o) {
   }
 
   {
-    json pbrMetallicRoughness;
+    ::detail::json pbrMetallicRoughness;
     SerializeGltfPbrMetallicRoughness(material.pbrMetallicRoughness,
                                       pbrMetallicRoughness);
     // Issue 204
@@ -7281,16 +7281,16 @@ static void SerializeGltfMaterial(const Material &material, json &o) {
     // `pbrMetallicRoughness : null`, which cannot be read by other glTF
     // importers (and validators).
     //
-    if (!JsonIsNull(pbrMetallicRoughness)) {
-      JsonAddMember(o, "pbrMetallicRoughness", std::move(pbrMetallicRoughness));
+    if (!detail::JsonIsNull(pbrMetallicRoughness)) {
+      detail::JsonAddMember(o, "pbrMetallicRoughness", std::move(pbrMetallicRoughness));
     }
   }
 
 #if 0  // legacy way. just for the record.
   if (material.values.size()) {
-    json pbrMetallicRoughness;
+    ::detail::json pbrMetallicRoughness;
     SerializeParameterMap(material.values, pbrMetallicRoughness);
-    JsonAddMember(o, "pbrMetallicRoughness", std::move(pbrMetallicRoughness));
+    detail::JsonAddMember(o, "pbrMetallicRoughness", std::move(pbrMetallicRoughness));
   }
 
   SerializeParameterMap(material.additionalValues, o);
@@ -7305,20 +7305,20 @@ static void SerializeGltfMaterial(const Material &material, json &o) {
   }
 }
 
-static void SerializeGltfMesh(const Mesh &mesh, json &o) {
-  json primitives;
-  JsonReserveArray(primitives, mesh.primitives.size());
+static void SerializeGltfMesh(const Mesh &mesh, ::detail::json &o) {
+  ::detail::json primitives;
+  detail::JsonReserveArray(primitives, mesh.primitives.size());
   for (unsigned int i = 0; i < mesh.primitives.size(); ++i) {
-    json primitive;
+    ::detail::json primitive;
     const Primitive &gltfPrimitive = mesh.primitives[i];  // don't make a copy
     {
-      json attributes;
+      ::detail::json attributes;
       for (auto attrIt = gltfPrimitive.attributes.begin();
            attrIt != gltfPrimitive.attributes.end(); ++attrIt) {
         SerializeNumberProperty<int>(attrIt->first, attrIt->second, attributes);
       }
 
-      JsonAddMember(primitive, "attributes", std::move(attributes));
+      detail::JsonAddMember(primitive, "attributes", std::move(attributes));
     }
 
     // Indices is optional
@@ -7334,19 +7334,19 @@ static void SerializeGltfMesh(const Mesh &mesh, json &o) {
 
     // Morph targets
     if (gltfPrimitive.targets.size()) {
-      json targets;
-      JsonReserveArray(targets, gltfPrimitive.targets.size());
+      ::detail::json targets;
+      detail::JsonReserveArray(targets, gltfPrimitive.targets.size());
       for (unsigned int k = 0; k < gltfPrimitive.targets.size(); ++k) {
-        json targetAttributes;
+        ::detail::json targetAttributes;
         std::map<std::string, int> targetData = gltfPrimitive.targets[k];
         for (std::map<std::string, int>::iterator attrIt = targetData.begin();
              attrIt != targetData.end(); ++attrIt) {
           SerializeNumberProperty<int>(attrIt->first, attrIt->second,
                                        targetAttributes);
         }
-        JsonPushBack(targets, std::move(targetAttributes));
+        detail::JsonPushBack(targets, std::move(targetAttributes));
       }
-      JsonAddMember(primitive, "targets", std::move(targets));
+      detail::JsonAddMember(primitive, "targets", std::move(targets));
     }
 
     SerializeExtensionMap(gltfPrimitive.extensions, primitive);
@@ -7355,10 +7355,10 @@ static void SerializeGltfMesh(const Mesh &mesh, json &o) {
       SerializeValue("extras", gltfPrimitive.extras, primitive);
     }
 
-    JsonPushBack(primitives, std::move(primitive));
+    detail::JsonPushBack(primitives, std::move(primitive));
   }
 
-  JsonAddMember(o, "primitives", std::move(primitives));
+  detail::JsonAddMember(o, "primitives", std::move(primitives));
 
   if (mesh.weights.size()) {
     SerializeNumberArrayProperty<double>("weights", mesh.weights, o);
@@ -7374,7 +7374,7 @@ static void SerializeGltfMesh(const Mesh &mesh, json &o) {
   }
 }
 
-static void SerializeSpotLight(const SpotLight &spot, json &o) {
+static void SerializeSpotLight(const SpotLight &spot, ::detail::json &o) {
   SerializeNumberProperty("innerConeAngle", spot.innerConeAngle, o);
   SerializeNumberProperty("outerConeAngle", spot.outerConeAngle, o);
   SerializeExtensionMap(spot.extensions, o);
@@ -7383,7 +7383,7 @@ static void SerializeSpotLight(const SpotLight &spot, json &o) {
   }
 }
 
-static void SerializeGltfLight(const Light &light, json &o) {
+static void SerializeGltfLight(const Light &light, ::detail::json &o) {
   if (!light.name.empty()) SerializeStringProperty("name", light.name, o);
   SerializeNumberProperty("intensity", light.intensity, o);
   if (light.range > 0.0) {
@@ -7392,9 +7392,9 @@ static void SerializeGltfLight(const Light &light, json &o) {
   SerializeNumberArrayProperty("color", light.color, o);
   SerializeStringProperty("type", light.type, o);
   if (light.type == "spot") {
-    json spot;
+    ::detail::json spot;
     SerializeSpotLight(light.spot, spot);
-    JsonAddMember(o, "spot", std::move(spot));
+    detail::JsonAddMember(o, "spot", std::move(spot));
   }
   SerializeExtensionMap(light.extensions, o);
   if (light.extras.Type() != NULL_TYPE) {
@@ -7402,7 +7402,7 @@ static void SerializeGltfLight(const Light &light, json &o) {
   }
 }
 
-static void SerializeGltfNode(const Node &node, json &o) {
+static void SerializeGltfNode(const Node &node, ::detail::json &o) {
   if (node.translation.size() > 0) {
     SerializeNumberArrayProperty<double>("translation", node.translation, o);
   }
@@ -7440,7 +7440,7 @@ static void SerializeGltfNode(const Node &node, json &o) {
   SerializeNumberArrayProperty<int>("children", node.children, o);
 }
 
-static void SerializeGltfSampler(const Sampler &sampler, json &o) {
+static void SerializeGltfSampler(const Sampler &sampler, ::detail::json &o) {
   if (!sampler.name.empty()) {
     SerializeStringProperty("name", sampler.name, o);
   }
@@ -7460,7 +7460,7 @@ static void SerializeGltfSampler(const Sampler &sampler, json &o) {
 }
 
 static void SerializeGltfOrthographicCamera(const OrthographicCamera &camera,
-                                            json &o) {
+                                            ::detail::json &o) {
   SerializeNumberProperty("zfar", camera.zfar, o);
   SerializeNumberProperty("znear", camera.znear, o);
   SerializeNumberProperty("xmag", camera.xmag, o);
@@ -7472,7 +7472,7 @@ static void SerializeGltfOrthographicCamera(const OrthographicCamera &camera,
 }
 
 static void SerializeGltfPerspectiveCamera(const PerspectiveCamera &camera,
-                                           json &o) {
+                                           ::detail::json &o) {
   SerializeNumberProperty("zfar", camera.zfar, o);
   SerializeNumberProperty("znear", camera.znear, o);
   if (camera.aspectRatio > 0) {
@@ -7488,20 +7488,20 @@ static void SerializeGltfPerspectiveCamera(const PerspectiveCamera &camera,
   }
 }
 
-static void SerializeGltfCamera(const Camera &camera, json &o) {
+static void SerializeGltfCamera(const Camera &camera, ::detail::json &o) {
   SerializeStringProperty("type", camera.type, o);
   if (!camera.name.empty()) {
     SerializeStringProperty("name", camera.name, o);
   }
 
   if (camera.type.compare("orthographic") == 0) {
-    json orthographic;
+    ::detail::json orthographic;
     SerializeGltfOrthographicCamera(camera.orthographic, orthographic);
-    JsonAddMember(o, "orthographic", std::move(orthographic));
+    detail::JsonAddMember(o, "orthographic", std::move(orthographic));
   } else if (camera.type.compare("perspective") == 0) {
-    json perspective;
+    ::detail::json perspective;
     SerializeGltfPerspectiveCamera(camera.perspective, perspective);
-    JsonAddMember(o, "perspective", std::move(perspective));
+    detail::JsonAddMember(o, "perspective", std::move(perspective));
   } else {
     // ???
   }
@@ -7512,7 +7512,7 @@ static void SerializeGltfCamera(const Camera &camera, json &o) {
   SerializeExtensionMap(camera.extensions, o);
 }
 
-static void SerializeGltfScene(const Scene &scene, json &o) {
+static void SerializeGltfScene(const Scene &scene, ::detail::json &o) {
   SerializeNumberArrayProperty<int>("nodes", scene.nodes, o);
 
   if (scene.name.size()) {
@@ -7524,7 +7524,7 @@ static void SerializeGltfScene(const Scene &scene, json &o) {
   SerializeExtensionMap(scene.extensions, o);
 }
 
-static void SerializeGltfSkin(const Skin &skin, json &o) {
+static void SerializeGltfSkin(const Skin &skin, ::detail::json &o) {
   // required
   SerializeNumberArrayProperty<int>("joints", skin.joints, o);
 
@@ -7541,7 +7541,7 @@ static void SerializeGltfSkin(const Skin &skin, json &o) {
   }
 }
 
-static void SerializeGltfTexture(const Texture &texture, json &o) {
+static void SerializeGltfTexture(const Texture &texture, ::detail::json &o) {
   if (texture.sampler > -1) {
     SerializeNumberProperty("sampler", texture.sampler, o);
   }
@@ -7560,49 +7560,49 @@ static void SerializeGltfTexture(const Texture &texture, json &o) {
 ///
 /// Serialize all properties except buffers and images.
 ///
-static void SerializeGltfModel(const Model *model, json &o) {
+static void SerializeGltfModel(const Model *model, ::detail::json &o) {
   // ACCESSORS
   if (model->accessors.size()) {
-    json accessors;
-    JsonReserveArray(accessors, model->accessors.size());
+    ::detail::json accessors;
+    detail::JsonReserveArray(accessors, model->accessors.size());
     for (unsigned int i = 0; i < model->accessors.size(); ++i) {
-      json accessor;
+      ::detail::json accessor;
       SerializeGltfAccessor(model->accessors[i], accessor);
-      JsonPushBack(accessors, std::move(accessor));
+      detail::JsonPushBack(accessors, std::move(accessor));
     }
-    JsonAddMember(o, "accessors", std::move(accessors));
+    detail::JsonAddMember(o, "accessors", std::move(accessors));
   }
 
   // ANIMATIONS
   if (model->animations.size()) {
-    json animations;
-    JsonReserveArray(animations, model->animations.size());
+    ::detail::json animations;
+    detail::JsonReserveArray(animations, model->animations.size());
     for (unsigned int i = 0; i < model->animations.size(); ++i) {
       if (model->animations[i].channels.size()) {
-        json animation;
+        ::detail::json animation;
         SerializeGltfAnimation(model->animations[i], animation);
-        JsonPushBack(animations, std::move(animation));
+        detail::JsonPushBack(animations, std::move(animation));
       }
     }
 
-    JsonAddMember(o, "animations", std::move(animations));
+    detail::JsonAddMember(o, "animations", std::move(animations));
   }
 
   // ASSET
-  json asset;
+  ::detail::json asset;
   SerializeGltfAsset(model->asset, asset);
-  JsonAddMember(o, "asset", std::move(asset));
+  detail::JsonAddMember(o, "asset", std::move(asset));
 
   // BUFFERVIEWS
   if (model->bufferViews.size()) {
-    json bufferViews;
-    JsonReserveArray(bufferViews, model->bufferViews.size());
+    ::detail::json bufferViews;
+    detail::JsonReserveArray(bufferViews, model->bufferViews.size());
     for (unsigned int i = 0; i < model->bufferViews.size(); ++i) {
-      json bufferView;
+      ::detail::json bufferView;
       SerializeGltfBufferView(model->bufferViews[i], bufferView);
-      JsonPushBack(bufferViews, std::move(bufferView));
+      detail::JsonPushBack(bufferViews, std::move(bufferView));
     }
-    JsonAddMember(o, "bufferViews", std::move(bufferViews));
+    detail::JsonAddMember(o, "bufferViews", std::move(bufferViews));
   }
 
   // Extensions required
@@ -7613,48 +7613,48 @@ static void SerializeGltfModel(const Model *model, json &o) {
 
   // MATERIALS
   if (model->materials.size()) {
-    json materials;
-    JsonReserveArray(materials, model->materials.size());
+    ::detail::json materials;
+    detail::JsonReserveArray(materials, model->materials.size());
     for (unsigned int i = 0; i < model->materials.size(); ++i) {
-      json material;
+      ::detail::json material;
       SerializeGltfMaterial(model->materials[i], material);
 
-      if (JsonIsNull(material)) {
+      if (detail::JsonIsNull(material)) {
         // Issue 294.
         // `material` does not have any required parameters
         // so the result may be null(unmodified) when all material parameters
         // have default value.
         //
         // null is not allowed thus we create an empty JSON object.
-        JsonSetObject(material);
+        detail::JsonSetObject(material);
       }
-      JsonPushBack(materials, std::move(material));
+      detail::JsonPushBack(materials, std::move(material));
     }
-    JsonAddMember(o, "materials", std::move(materials));
+    detail::JsonAddMember(o, "materials", std::move(materials));
   }
 
   // MESHES
   if (model->meshes.size()) {
-    json meshes;
-    JsonReserveArray(meshes, model->meshes.size());
+    ::detail::json meshes;
+    detail::JsonReserveArray(meshes, model->meshes.size());
     for (unsigned int i = 0; i < model->meshes.size(); ++i) {
-      json mesh;
+      ::detail::json mesh;
       SerializeGltfMesh(model->meshes[i], mesh);
-      JsonPushBack(meshes, std::move(mesh));
+      detail::JsonPushBack(meshes, std::move(mesh));
     }
-    JsonAddMember(o, "meshes", std::move(meshes));
+    detail::JsonAddMember(o, "meshes", std::move(meshes));
   }
 
   // NODES
   if (model->nodes.size()) {
-    json nodes;
-    JsonReserveArray(nodes, model->nodes.size());
+    ::detail::json nodes;
+    detail::JsonReserveArray(nodes, model->nodes.size());
     for (unsigned int i = 0; i < model->nodes.size(); ++i) {
-      json node;
+      ::detail::json node;
       SerializeGltfNode(model->nodes[i], node);
-      JsonPushBack(nodes, std::move(node));
+      detail::JsonPushBack(nodes, std::move(node));
     }
-    JsonAddMember(o, "nodes", std::move(nodes));
+    detail::JsonAddMember(o, "nodes", std::move(nodes));
   }
 
   // SCENE
@@ -7664,62 +7664,62 @@ static void SerializeGltfModel(const Model *model, json &o) {
 
   // SCENES
   if (model->scenes.size()) {
-    json scenes;
-    JsonReserveArray(scenes, model->scenes.size());
+    ::detail::json scenes;
+    detail::JsonReserveArray(scenes, model->scenes.size());
     for (unsigned int i = 0; i < model->scenes.size(); ++i) {
-      json currentScene;
+      ::detail::json currentScene;
       SerializeGltfScene(model->scenes[i], currentScene);
-      JsonPushBack(scenes, std::move(currentScene));
+      detail::JsonPushBack(scenes, std::move(currentScene));
     }
-    JsonAddMember(o, "scenes", std::move(scenes));
+    detail::JsonAddMember(o, "scenes", std::move(scenes));
   }
 
   // SKINS
   if (model->skins.size()) {
-    json skins;
-    JsonReserveArray(skins, model->skins.size());
+    ::detail::json skins;
+    detail::JsonReserveArray(skins, model->skins.size());
     for (unsigned int i = 0; i < model->skins.size(); ++i) {
-      json skin;
+      ::detail::json skin;
       SerializeGltfSkin(model->skins[i], skin);
-      JsonPushBack(skins, std::move(skin));
+      detail::JsonPushBack(skins, std::move(skin));
     }
-    JsonAddMember(o, "skins", std::move(skins));
+    detail::JsonAddMember(o, "skins", std::move(skins));
   }
 
   // TEXTURES
   if (model->textures.size()) {
-    json textures;
-    JsonReserveArray(textures, model->textures.size());
+    ::detail::json textures;
+    detail::JsonReserveArray(textures, model->textures.size());
     for (unsigned int i = 0; i < model->textures.size(); ++i) {
-      json texture;
+      ::detail::json texture;
       SerializeGltfTexture(model->textures[i], texture);
-      JsonPushBack(textures, std::move(texture));
+      detail::JsonPushBack(textures, std::move(texture));
     }
-    JsonAddMember(o, "textures", std::move(textures));
+    detail::JsonAddMember(o, "textures", std::move(textures));
   }
 
   // SAMPLERS
   if (model->samplers.size()) {
-    json samplers;
-    JsonReserveArray(samplers, model->samplers.size());
+    ::detail::json samplers;
+    detail::JsonReserveArray(samplers, model->samplers.size());
     for (unsigned int i = 0; i < model->samplers.size(); ++i) {
-      json sampler;
+      ::detail::json sampler;
       SerializeGltfSampler(model->samplers[i], sampler);
-      JsonPushBack(samplers, std::move(sampler));
+      detail::JsonPushBack(samplers, std::move(sampler));
     }
-    JsonAddMember(o, "samplers", std::move(samplers));
+    detail::JsonAddMember(o, "samplers", std::move(samplers));
   }
 
   // CAMERAS
   if (model->cameras.size()) {
-    json cameras;
-    JsonReserveArray(cameras, model->cameras.size());
+    ::detail::json cameras;
+    detail::JsonReserveArray(cameras, model->cameras.size());
     for (unsigned int i = 0; i < model->cameras.size(); ++i) {
-      json camera;
+      ::detail::json camera;
       SerializeGltfCamera(model->cameras[i], camera);
-      JsonPushBack(cameras, std::move(camera));
+      detail::JsonPushBack(cameras, std::move(camera));
     }
-    JsonAddMember(o, "cameras", std::move(cameras));
+    detail::JsonAddMember(o, "cameras", std::move(cameras));
   }
 
   // EXTENSIONS
@@ -7729,27 +7729,27 @@ static void SerializeGltfModel(const Model *model, json &o) {
 
   // LIGHTS as KHR_lights_punctual
   if (model->lights.size()) {
-    json lights;
-    JsonReserveArray(lights, model->lights.size());
+    ::detail::json lights;
+    detail::JsonReserveArray(lights, model->lights.size());
     for (unsigned int i = 0; i < model->lights.size(); ++i) {
-      json light;
+      ::detail::json light;
       SerializeGltfLight(model->lights[i], light);
-      JsonPushBack(lights, std::move(light));
+      detail::JsonPushBack(lights, std::move(light));
     }
-    json khr_lights_cmn;
-    JsonAddMember(khr_lights_cmn, "lights", std::move(lights));
-    json ext_j;
+    ::detail::json khr_lights_cmn;
+    detail::JsonAddMember(khr_lights_cmn, "lights", std::move(lights));
+    ::detail::json ext_j;
 
     {
-      json_const_iterator it;
-      if (FindMember(o, "extensions", it)) {
-        JsonAssign(ext_j, GetValue(it));
+      ::detail::json_const_iterator it;
+      if (detail::FindMember(o, "extensions", it)) {
+        detail::JsonAssign(ext_j, detail::GetValue(it));
       }
     }
 
-    JsonAddMember(ext_j, "KHR_lights_punctual", std::move(khr_lights_cmn));
+    detail::JsonAddMember(ext_j, "KHR_lights_punctual", std::move(khr_lights_cmn));
 
-    JsonAddMember(o, "extensions", std::move(ext_j));
+    detail::JsonAddMember(o, "extensions", std::move(ext_j));
 
     // Also add "KHR_lights_punctual" to `extensionsUsed`
     {
@@ -7889,7 +7889,7 @@ static bool WriteBinaryGltfFile(const std::string &output,
 bool TinyGLTF::WriteGltfSceneToStream(const Model *model, std::ostream &stream,
                                       bool prettyPrint = true,
                                       bool writeBinary = false) {
-  JsonDocument output;
+  ::detail::JsonDocument output;
 
   /// Serialize all properties except buffers and images.
   SerializeGltfModel(model, output);
@@ -7897,26 +7897,26 @@ bool TinyGLTF::WriteGltfSceneToStream(const Model *model, std::ostream &stream,
   // BUFFERS
   std::vector<unsigned char> binBuffer;
   if (model->buffers.size()) {
-    json buffers;
-    JsonReserveArray(buffers, model->buffers.size());
+    ::detail::json buffers;
+    detail::JsonReserveArray(buffers, model->buffers.size());
     for (unsigned int i = 0; i < model->buffers.size(); ++i) {
-      json buffer;
+      ::detail::json buffer;
       if (writeBinary && i == 0 && model->buffers[i].uri.empty()) {
         SerializeGltfBufferBin(model->buffers[i], buffer, binBuffer);
       } else {
         SerializeGltfBuffer(model->buffers[i], buffer);
       }
-      JsonPushBack(buffers, std::move(buffer));
+      detail::JsonPushBack(buffers, std::move(buffer));
     }
-    JsonAddMember(output, "buffers", std::move(buffers));
+    detail::JsonAddMember(output, "buffers", std::move(buffers));
   }
 
   // IMAGES
   if (model->images.size()) {
-    json images;
-    JsonReserveArray(images, model->images.size());
+    ::detail::json images;
+    detail::JsonReserveArray(images, model->images.size());
     for (unsigned int i = 0; i < model->images.size(); ++i) {
-      json image;
+      ::detail::json image;
 
       std::string dummystring = "";
       // UpdateImageObject need baseDir but only uses it if embeddedImages is
@@ -7929,15 +7929,15 @@ bool TinyGLTF::WriteGltfSceneToStream(const Model *model, std::ostream &stream,
         return false;
       }
       SerializeGltfImage(model->images[i], uri, image);
-      JsonPushBack(images, std::move(image));
+      detail::JsonPushBack(images, std::move(image));
     }
-    JsonAddMember(output, "images", std::move(images));
+    detail::JsonAddMember(output, "images", std::move(images));
   }
 
   if (writeBinary) {
-    return WriteBinaryGltfStream(stream, JsonToString(output), binBuffer);
+    return WriteBinaryGltfStream(stream, detail::JsonToString(output), binBuffer);
   } else {
-    return WriteGltfStream(stream, JsonToString(output, prettyPrint ? 2 : -1));
+    return WriteGltfStream(stream, detail::JsonToString(output, prettyPrint ? 2 : -1));
   }
 }
 
@@ -7947,7 +7947,7 @@ bool TinyGLTF::WriteGltfSceneToFile(const Model *model,
                                     bool embedBuffers = false,
                                     bool prettyPrint = true,
                                     bool writeBinary = false) {
-  JsonDocument output;
+  ::detail::JsonDocument output;
   std::string defaultBinFilename = GetBaseFilename(filename);
   std::string defaultBinFileExt = ".bin";
   std::string::size_type pos =
@@ -7967,10 +7967,10 @@ bool TinyGLTF::WriteGltfSceneToFile(const Model *model,
   std::vector<std::string> usedFilenames;
   std::vector<unsigned char> binBuffer;
   if (model->buffers.size()) {
-    json buffers;
-    JsonReserveArray(buffers, model->buffers.size());
+    ::detail::json buffers;
+    detail::JsonReserveArray(buffers, model->buffers.size());
     for (unsigned int i = 0; i < model->buffers.size(); ++i) {
-      json buffer;
+      ::detail::json buffer;
       if (writeBinary && i == 0 && model->buffers[i].uri.empty()) {
         SerializeGltfBufferBin(model->buffers[i], buffer, binBuffer);
       } else if (embedBuffers) {
@@ -8016,17 +8016,17 @@ bool TinyGLTF::WriteGltfSceneToFile(const Model *model,
           return false;
         }
       }
-      JsonPushBack(buffers, std::move(buffer));
+      detail::JsonPushBack(buffers, std::move(buffer));
     }
-    JsonAddMember(output, "buffers", std::move(buffers));
+    detail::JsonAddMember(output, "buffers", std::move(buffers));
   }
 
   // IMAGES
   if (model->images.size()) {
-    json images;
-    JsonReserveArray(images, model->images.size());
+    ::detail::json images;
+    detail::JsonReserveArray(images, model->images.size());
     for (unsigned int i = 0; i < model->images.size(); ++i) {
-      json image;
+      ::detail::json image;
 
       std::string uri;
       if (!UpdateImageObject(model->images[i], baseDir, int(i), embedImages,
@@ -8035,15 +8035,15 @@ bool TinyGLTF::WriteGltfSceneToFile(const Model *model,
         return false;
       }
       SerializeGltfImage(model->images[i], uri, image);
-      JsonPushBack(images, std::move(image));
+      detail::JsonPushBack(images, std::move(image));
     }
-    JsonAddMember(output, "images", std::move(images));
+    detail::JsonAddMember(output, "images", std::move(images));
   }
 
   if (writeBinary) {
-    return WriteBinaryGltfFile(filename, JsonToString(output), binBuffer);
+    return WriteBinaryGltfFile(filename, detail::JsonToString(output), binBuffer);
   } else {
-    return WriteGltfFile(filename, JsonToString(output, (prettyPrint ? 2 : -1)));
+    return WriteGltfFile(filename, detail::JsonToString(output, (prettyPrint ? 2 : -1)));
   }
 }
 

--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -1705,6 +1705,7 @@ class TinyGLTF {
 #endif
 #endif
 
+namespace tinygltf {
 namespace detail {
 #ifdef TINYGLTF_USE_RAPIDJSON
 
@@ -1781,10 +1782,11 @@ void JsonParse(JsonDocument &doc, const char *str, size_t length,
   (void)throwExc;
   doc.Parse(str, length);
 #else
-  doc = ::detail::json::parse(str, str + length, nullptr, throwExc);
+  doc = detail::json::parse(str, str + length, nullptr, throwExc);
 #endif
 }
 }  // namespace
+}
 
 #ifdef __APPLE__
 #include "TargetConditionals.h"
@@ -3068,7 +3070,7 @@ bool DecodeDataURI(std::vector<unsigned char> *out, std::string &mime_type,
 }
 
 namespace detail {
-bool GetInt(const ::detail::json &o, int &val) {
+bool GetInt(const detail::json &o, int &val) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   if (!o.IsDouble()) {
     if (o.IsInt()) {
@@ -3090,8 +3092,8 @@ bool GetInt(const ::detail::json &o, int &val) {
 #else
   auto type = o.type();
 
-  if ((type == ::detail::json::value_t::number_integer) ||
-      (type == ::detail::json::value_t::number_unsigned)) {
+  if ((type == detail::json::value_t::number_integer) ||
+      (type == detail::json::value_t::number_unsigned)) {
     val = static_cast<int>(o.get<int64_t>());
     return true;
   }
@@ -3101,7 +3103,7 @@ bool GetInt(const ::detail::json &o, int &val) {
 }
 
 #ifdef TINYGLTF_USE_RAPIDJSON
-bool GetDouble(const ::detail::json &o, double &val) {
+bool GetDouble(const detail::json &o, double &val) {
   if (o.IsDouble()) {
     val = o.GetDouble();
     return true;
@@ -3111,7 +3113,7 @@ bool GetDouble(const ::detail::json &o, double &val) {
 }
 #endif
 
-bool GetNumber(const ::detail::json &o, double &val) {
+bool GetNumber(const detail::json &o, double &val) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   if (o.IsNumber()) {
     val = o.GetDouble();
@@ -3129,7 +3131,7 @@ bool GetNumber(const ::detail::json &o, double &val) {
 #endif
 }
 
-bool GetString(const ::detail::json &o, std::string &val) {
+bool GetString(const detail::json &o, std::string &val) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   if (o.IsString()) {
     val = o.GetString();
@@ -3138,7 +3140,7 @@ bool GetString(const ::detail::json &o, std::string &val) {
 
   return false;
 #else
-  if (o.type() == ::detail::json::value_t::string) {
+  if (o.type() == detail::json::value_t::string) {
     val = o.get<std::string>();
     return true;
   }
@@ -3147,7 +3149,7 @@ bool GetString(const ::detail::json &o, std::string &val) {
 #endif
 }
 
-bool IsArray(const ::detail::json &o) {
+bool IsArray(const detail::json &o) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   return o.IsArray();
 #else
@@ -3155,7 +3157,7 @@ bool IsArray(const ::detail::json &o) {
 #endif
 }
 
-::detail::json_const_array_iterator ArrayBegin(const ::detail::json &o) {
+detail::json_const_array_iterator ArrayBegin(const detail::json &o) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   return o.Begin();
 #else
@@ -3163,7 +3165,7 @@ bool IsArray(const ::detail::json &o) {
 #endif
 }
 
-::detail::json_const_array_iterator ArrayEnd(const ::detail::json &o) {
+detail::json_const_array_iterator ArrayEnd(const detail::json &o) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   return o.End();
 #else
@@ -3171,7 +3173,7 @@ bool IsArray(const ::detail::json &o) {
 #endif
 }
 
-bool IsObject(const ::detail::json &o) {
+bool IsObject(const detail::json &o) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   return o.IsObject();
 #else
@@ -3179,7 +3181,7 @@ bool IsObject(const ::detail::json &o) {
 #endif
 }
 
-::detail::json_const_iterator ObjectBegin(const ::detail::json &o) {
+detail::json_const_iterator ObjectBegin(const detail::json &o) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   return o.MemberBegin();
 #else
@@ -3187,7 +3189,7 @@ bool IsObject(const ::detail::json &o) {
 #endif
 }
 
-::detail::json_const_iterator ObjectEnd(const ::detail::json &o) {
+detail::json_const_iterator ObjectEnd(const detail::json &o) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   return o.MemberEnd();
 #else
@@ -3197,7 +3199,7 @@ bool IsObject(const ::detail::json &o) {
 
 // Making this a const char* results in a pointer to a temporary when
 // TINYGLTF_USE_RAPIDJSON is off.
-std::string GetKey(::detail::json_const_iterator &it) {
+std::string GetKey(detail::json_const_iterator &it) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   return it->name.GetString();
 #else
@@ -3205,7 +3207,7 @@ std::string GetKey(::detail::json_const_iterator &it) {
 #endif
 }
 
-bool FindMember(const ::detail::json &o, const char *member, ::detail::json_const_iterator &it) {
+bool FindMember(const detail::json &o, const char *member, detail::json_const_iterator &it) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   if (!o.IsObject()) {
     return false;
@@ -3218,7 +3220,7 @@ bool FindMember(const ::detail::json &o, const char *member, ::detail::json_cons
 #endif
 }
 
-const ::detail::json &GetValue(::detail::json_const_iterator &it) {
+const detail::json &GetValue(detail::json_const_iterator &it) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   return it->value;
 #else
@@ -3226,7 +3228,7 @@ const ::detail::json &GetValue(::detail::json_const_iterator &it) {
 #endif
 }
 
-std::string JsonToString(const ::detail::json &o, int spacing = -1) {
+std::string JsonToString(const detail::json &o, int spacing = -1) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   using namespace rapidjson;
   StringBuffer buffer;
@@ -3252,7 +3254,7 @@ std::string JsonToString(const ::detail::json &o, int spacing = -1) {
 
 }  // namespace
 
-static bool ParseJsonAsValue(Value *ret, const ::detail::json &o) {
+static bool ParseJsonAsValue(Value *ret, const detail::json &o) {
   Value val{};
 #ifdef TINYGLTF_USE_RAPIDJSON
   using rapidjson::Type;
@@ -3302,7 +3304,7 @@ static bool ParseJsonAsValue(Value *ret, const ::detail::json &o) {
   }
 #else
   switch (o.type()) {
-    case ::detail::json::value_t::object: {
+    case detail::json::value_t::object: {
       Value::Object value_object;
       for (auto it = o.begin(); it != o.end(); it++) {
         Value entry;
@@ -3312,7 +3314,7 @@ static bool ParseJsonAsValue(Value *ret, const ::detail::json &o) {
       }
       if (value_object.size() > 0) val = Value(std::move(value_object));
     } break;
-    case ::detail::json::value_t::array: {
+    case detail::json::value_t::array: {
       Value::Array value_array;
       value_array.reserve(o.size());
       for (auto it = o.begin(); it != o.end(); it++) {
@@ -3323,22 +3325,22 @@ static bool ParseJsonAsValue(Value *ret, const ::detail::json &o) {
       }
       if (value_array.size() > 0) val = Value(std::move(value_array));
     } break;
-    case ::detail::json::value_t::string:
+    case detail::json::value_t::string:
       val = Value(o.get<std::string>());
       break;
-    case ::detail::json::value_t::boolean:
+    case detail::json::value_t::boolean:
       val = Value(o.get<bool>());
       break;
-    case ::detail::json::value_t::number_integer:
-    case ::detail::json::value_t::number_unsigned:
+    case detail::json::value_t::number_integer:
+    case detail::json::value_t::number_unsigned:
       val = Value(static_cast<int>(o.get<int64_t>()));
       break;
-    case ::detail::json::value_t::number_float:
+    case detail::json::value_t::number_float:
       val = Value(o.get<double>());
       break;
-    case ::detail::json::value_t::null:
-    case ::detail::json::value_t::discarded:
-    case ::detail::json::value_t::binary:
+    case detail::json::value_t::null:
+    case detail::json::value_t::discarded:
+    case detail::json::value_t::binary:
       // default:
       break;
   }
@@ -3350,8 +3352,8 @@ static bool ParseJsonAsValue(Value *ret, const ::detail::json &o) {
   return isNotNull;
 }
 
-static bool ParseExtrasProperty(Value *ret, const ::detail::json &o) {
-  ::detail::json_const_iterator it;
+static bool ParseExtrasProperty(Value *ret, const detail::json &o) {
+  detail::json_const_iterator it;
   if (!detail::FindMember(o, "extras", it)) {
     return false;
   }
@@ -3359,11 +3361,11 @@ static bool ParseExtrasProperty(Value *ret, const ::detail::json &o) {
   return ParseJsonAsValue(ret, detail::GetValue(it));
 }
 
-static bool ParseBooleanProperty(bool *ret, std::string *err, const ::detail::json &o,
+static bool ParseBooleanProperty(bool *ret, std::string *err, const detail::json &o,
                                  const std::string &property,
                                  const bool required,
                                  const std::string &parent_node = "") {
-  ::detail::json_const_iterator it;
+  detail::json_const_iterator it;
   if (!detail::FindMember(o, property.c_str(), it)) {
     if (required) {
       if (err) {
@@ -3408,11 +3410,11 @@ static bool ParseBooleanProperty(bool *ret, std::string *err, const ::detail::js
   return true;
 }
 
-static bool ParseIntegerProperty(int *ret, std::string *err, const ::detail::json &o,
+static bool ParseIntegerProperty(int *ret, std::string *err, const detail::json &o,
                                  const std::string &property,
                                  const bool required,
                                  const std::string &parent_node = "") {
-  ::detail::json_const_iterator it;
+  detail::json_const_iterator it;
   if (!detail::FindMember(o, property.c_str(), it)) {
     if (required) {
       if (err) {
@@ -3444,11 +3446,11 @@ static bool ParseIntegerProperty(int *ret, std::string *err, const ::detail::jso
   return true;
 }
 
-static bool ParseUnsignedProperty(size_t *ret, std::string *err, const ::detail::json &o,
+static bool ParseUnsignedProperty(size_t *ret, std::string *err, const detail::json &o,
                                   const std::string &property,
                                   const bool required,
                                   const std::string &parent_node = "") {
-  ::detail::json_const_iterator it;
+  detail::json_const_iterator it;
   if (!detail::FindMember(o, property.c_str(), it)) {
     if (required) {
       if (err) {
@@ -3497,11 +3499,11 @@ static bool ParseUnsignedProperty(size_t *ret, std::string *err, const ::detail:
   return true;
 }
 
-static bool ParseNumberProperty(double *ret, std::string *err, const ::detail::json &o,
+static bool ParseNumberProperty(double *ret, std::string *err, const detail::json &o,
                                 const std::string &property,
                                 const bool required,
                                 const std::string &parent_node = "") {
-  ::detail::json_const_iterator it;
+  detail::json_const_iterator it;
 
   if (!detail::FindMember(o, property.c_str(), it)) {
     if (required) {
@@ -3536,10 +3538,10 @@ static bool ParseNumberProperty(double *ret, std::string *err, const ::detail::j
 }
 
 static bool ParseNumberArrayProperty(std::vector<double> *ret, std::string *err,
-                                     const ::detail::json &o, const std::string &property,
+                                     const detail::json &o, const std::string &property,
                                      bool required,
                                      const std::string &parent_node = "") {
-  ::detail::json_const_iterator it;
+  detail::json_const_iterator it;
   if (!detail::FindMember(o, property.c_str(), it)) {
     if (required) {
       if (err) {
@@ -3590,11 +3592,11 @@ static bool ParseNumberArrayProperty(std::vector<double> *ret, std::string *err,
 }
 
 static bool ParseIntegerArrayProperty(std::vector<int> *ret, std::string *err,
-                                      const ::detail::json &o,
+                                      const detail::json &o,
                                       const std::string &property,
                                       bool required,
                                       const std::string &parent_node = "") {
-  ::detail::json_const_iterator it;
+  detail::json_const_iterator it;
   if (!detail::FindMember(o, property.c_str(), it)) {
     if (required) {
       if (err) {
@@ -3645,10 +3647,10 @@ static bool ParseIntegerArrayProperty(std::vector<int> *ret, std::string *err,
 }
 
 static bool ParseStringProperty(
-    std::string *ret, std::string *err, const ::detail::json &o,
+    std::string *ret, std::string *err, const detail::json &o,
     const std::string &property, bool required,
     const std::string &parent_node = std::string()) {
-  ::detail::json_const_iterator it;
+  detail::json_const_iterator it;
   if (!detail::FindMember(o, property.c_str(), it)) {
     if (required) {
       if (err) {
@@ -3681,11 +3683,11 @@ static bool ParseStringProperty(
 }
 
 static bool ParseStringIntegerProperty(std::map<std::string, int> *ret,
-                                       std::string *err, const ::detail::json &o,
+                                       std::string *err, const detail::json &o,
                                        const std::string &property,
                                        bool required,
                                        const std::string &parent = "") {
-  ::detail::json_const_iterator it;
+  detail::json_const_iterator it;
   if (!detail::FindMember(o, property.c_str(), it)) {
     if (required) {
       if (err) {
@@ -3700,7 +3702,7 @@ static bool ParseStringIntegerProperty(std::map<std::string, int> *ret,
     return false;
   }
 
-  const ::detail::json &dict = detail::GetValue(it);
+  const detail::json &dict = detail::GetValue(it);
 
   // Make sure we are dealing with an object / dictionary.
   if (!detail::IsObject(dict)) {
@@ -3714,8 +3716,8 @@ static bool ParseStringIntegerProperty(std::map<std::string, int> *ret,
 
   ret->clear();
 
-  ::detail::json_const_iterator dictIt(detail::ObjectBegin(dict));
-  ::detail::json_const_iterator dictItEnd(detail::ObjectEnd(dict));
+  detail::json_const_iterator dictIt(detail::ObjectBegin(dict));
+  detail::json_const_iterator dictItEnd(detail::ObjectEnd(dict));
 
   for (; dictIt != dictItEnd; ++dictIt) {
     int intVal;
@@ -3735,9 +3737,9 @@ static bool ParseStringIntegerProperty(std::map<std::string, int> *ret,
 }
 
 static bool ParseJSONProperty(std::map<std::string, double> *ret,
-                              std::string *err, const ::detail::json &o,
+                              std::string *err, const detail::json &o,
                               const std::string &property, bool required) {
-  ::detail::json_const_iterator it;
+  detail::json_const_iterator it;
   if (!detail::FindMember(o, property.c_str(), it)) {
     if (required) {
       if (err) {
@@ -3747,7 +3749,7 @@ static bool ParseJSONProperty(std::map<std::string, double> *ret,
     return false;
   }
 
-  const ::detail::json &obj = detail::GetValue(it);
+  const detail::json &obj = detail::GetValue(it);
 
   if (!detail::IsObject(obj)) {
     if (required) {
@@ -3760,8 +3762,8 @@ static bool ParseJSONProperty(std::map<std::string, double> *ret,
 
   ret->clear();
 
-  ::detail::json_const_iterator it2(detail::ObjectBegin(obj));
-  ::detail::json_const_iterator itEnd(detail::ObjectEnd(obj));
+  detail::json_const_iterator it2(detail::ObjectBegin(obj));
+  detail::json_const_iterator itEnd(detail::ObjectEnd(obj));
   for (; it2 != itEnd; ++it2) {
     double numVal;
     if (detail::GetNumber(detail::GetValue(it2), numVal))
@@ -3772,7 +3774,7 @@ static bool ParseJSONProperty(std::map<std::string, double> *ret,
 }
 
 static bool ParseParameterProperty(Parameter *param, std::string *err,
-                                   const ::detail::json &o, const std::string &prop,
+                                   const detail::json &o, const std::string &prop,
                                    bool required) {
   // A parameter value can either be a string or an array of either a boolean or
   // a number. Booleans of any kind aren't supported here. Granted, it
@@ -3805,10 +3807,10 @@ static bool ParseParameterProperty(Parameter *param, std::string *err,
 }
 
 static bool ParseExtensionsProperty(ExtensionMap *ret, std::string *err,
-                                    const ::detail::json &o) {
+                                    const detail::json &o) {
   (void)err;
 
-  ::detail::json_const_iterator it;
+  detail::json_const_iterator it;
   if (!detail::FindMember(o, "extensions", it)) {
     return false;
   }
@@ -3818,8 +3820,8 @@ static bool ParseExtensionsProperty(ExtensionMap *ret, std::string *err,
     return false;
   }
   ExtensionMap extensions;
-  ::detail::json_const_iterator extIt = detail::ObjectBegin(obj);  // it.value().begin();
-  ::detail::json_const_iterator extEnd = detail::ObjectEnd(obj);
+  detail::json_const_iterator extIt = detail::ObjectBegin(obj);  // it.value().begin();
+  detail::json_const_iterator extEnd = detail::ObjectEnd(obj);
   for (; extIt != extEnd; ++extIt) {
     auto &itObj = detail::GetValue(extIt);
     if (!detail::IsObject(itObj)) continue;
@@ -3838,7 +3840,7 @@ static bool ParseExtensionsProperty(ExtensionMap *ret, std::string *err,
   return true;
 }
 
-static bool ParseAsset(Asset *asset, std::string *err, const ::detail::json &o,
+static bool ParseAsset(Asset *asset, std::string *err, const detail::json &o,
                        bool store_original_json_for_extras_and_extensions) {
   ParseStringProperty(&asset->version, err, o, "version", true, "Asset");
   ParseStringProperty(&asset->generator, err, o, "generator", false, "Asset");
@@ -3852,13 +3854,13 @@ static bool ParseAsset(Asset *asset, std::string *err, const ::detail::json &o,
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extensions", it)) {
         asset->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extras", it)) {
         asset->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
@@ -3869,7 +3871,7 @@ static bool ParseAsset(Asset *asset, std::string *err, const ::detail::json &o,
 }
 
 static bool ParseImage(Image *image, const int image_idx, std::string *err,
-                       std::string *warn, const ::detail::json &o,
+                       std::string *warn, const detail::json &o,
                        bool store_original_json_for_extras_and_extensions,
                        const std::string &basedir, FsCallbacks *fs,
                        const URICallbacks *uri_cb,
@@ -3879,7 +3881,7 @@ static bool ParseImage(Image *image, const int image_idx, std::string *err,
 
   // schema says oneOf [`bufferView`, `uri`]
   // TODO(syoyo): Check the type of each parameters.
-  ::detail::json_const_iterator it;
+  detail::json_const_iterator it;
   bool hasBufferView = detail::FindMember(o, "bufferView", it);
   bool hasURI = detail::FindMember(o, "uri", it);
 
@@ -3910,13 +3912,13 @@ static bool ParseImage(Image *image, const int image_idx, std::string *err,
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      ::detail::json_const_iterator eit;
+      detail::json_const_iterator eit;
       if (detail::FindMember(o, "extensions", eit)) {
         image->extensions_json_string = detail::JsonToString(detail::GetValue(eit));
       }
     }
     {
-      ::detail::json_const_iterator eit;
+      detail::json_const_iterator eit;
       if (detail::FindMember(o, "extras", eit)) {
         image->extras_json_string = detail::JsonToString(detail::GetValue(eit));
       }
@@ -4028,7 +4030,7 @@ static bool ParseImage(Image *image, const int image_idx, std::string *err,
                           static_cast<int>(img.size()), load_image_user_data);
 }
 
-static bool ParseTexture(Texture *texture, std::string *err, const ::detail::json &o,
+static bool ParseTexture(Texture *texture, std::string *err, const detail::json &o,
                          bool store_original_json_for_extras_and_extensions,
                          const std::string &basedir) {
   (void)basedir;
@@ -4046,13 +4048,13 @@ static bool ParseTexture(Texture *texture, std::string *err, const ::detail::jso
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extensions", it)) {
         texture->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extras", it)) {
         texture->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
@@ -4065,7 +4067,7 @@ static bool ParseTexture(Texture *texture, std::string *err, const ::detail::jso
 }
 
 static bool ParseTextureInfo(
-    TextureInfo *texinfo, std::string *err, const ::detail::json &o,
+    TextureInfo *texinfo, std::string *err, const detail::json &o,
     bool store_original_json_for_extras_and_extensions) {
   if (texinfo == nullptr) {
     return false;
@@ -4083,13 +4085,13 @@ static bool ParseTextureInfo(
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extensions", it)) {
         texinfo->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extras", it)) {
         texinfo->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
@@ -4100,7 +4102,7 @@ static bool ParseTextureInfo(
 }
 
 static bool ParseNormalTextureInfo(
-    NormalTextureInfo *texinfo, std::string *err, const ::detail::json &o,
+    NormalTextureInfo *texinfo, std::string *err, const detail::json &o,
     bool store_original_json_for_extras_and_extensions) {
   if (texinfo == nullptr) {
     return false;
@@ -4119,13 +4121,13 @@ static bool ParseNormalTextureInfo(
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extensions", it)) {
         texinfo->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extras", it)) {
         texinfo->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
@@ -4136,7 +4138,7 @@ static bool ParseNormalTextureInfo(
 }
 
 static bool ParseOcclusionTextureInfo(
-    OcclusionTextureInfo *texinfo, std::string *err, const ::detail::json &o,
+    OcclusionTextureInfo *texinfo, std::string *err, const detail::json &o,
     bool store_original_json_for_extras_and_extensions) {
   if (texinfo == nullptr) {
     return false;
@@ -4155,13 +4157,13 @@ static bool ParseOcclusionTextureInfo(
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extensions", it)) {
         texinfo->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extras", it)) {
         texinfo->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
@@ -4171,7 +4173,7 @@ static bool ParseOcclusionTextureInfo(
   return true;
 }
 
-static bool ParseBuffer(Buffer *buffer, std::string *err, const ::detail::json &o,
+static bool ParseBuffer(Buffer *buffer, std::string *err, const detail::json &o,
                         bool store_original_json_for_extras_and_extensions,
                         FsCallbacks *fs, const URICallbacks *uri_cb,
                         const std::string &basedir, bool is_binary = false,
@@ -4194,7 +4196,7 @@ static bool ParseBuffer(Buffer *buffer, std::string *err, const ::detail::json &
     }
   }
 
-  ::detail::json_const_iterator type;
+  detail::json_const_iterator type;
   if (detail::FindMember(o, "type", type)) {
     std::string typeStr;
     if (detail::GetString(detail::GetValue(type), typeStr)) {
@@ -4287,13 +4289,13 @@ static bool ParseBuffer(Buffer *buffer, std::string *err, const ::detail::json &
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extensions", it)) {
         buffer->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extras", it)) {
         buffer->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
@@ -4304,7 +4306,7 @@ static bool ParseBuffer(Buffer *buffer, std::string *err, const ::detail::json &
 }
 
 static bool ParseBufferView(
-    BufferView *bufferView, std::string *err, const ::detail::json &o,
+    BufferView *bufferView, std::string *err, const detail::json &o,
     bool store_original_json_for_extras_and_extensions) {
   int buffer = -1;
   if (!ParseIntegerProperty(&buffer, err, o, "buffer", true, "BufferView")) {
@@ -4359,13 +4361,13 @@ static bool ParseBufferView(
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extensions", it)) {
         bufferView->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extras", it)) {
         bufferView->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
@@ -4380,7 +4382,7 @@ static bool ParseBufferView(
 }
 
 static bool ParseSparseAccessor(Accessor *accessor, std::string *err,
-                                const ::detail::json &o) {
+                                const detail::json &o) {
   accessor->sparse.isSparse = true;
 
   int count = 0;
@@ -4388,8 +4390,8 @@ static bool ParseSparseAccessor(Accessor *accessor, std::string *err,
     return false;
   }
 
-  ::detail::json_const_iterator indices_iterator;
-  ::detail::json_const_iterator values_iterator;
+  detail::json_const_iterator indices_iterator;
+  detail::json_const_iterator values_iterator;
   if (!detail::FindMember(o, "indices", indices_iterator)) {
     (*err) = "the sparse object of this accessor doesn't have indices";
     return false;
@@ -4400,8 +4402,8 @@ static bool ParseSparseAccessor(Accessor *accessor, std::string *err,
     return false;
   }
 
-  const ::detail::json &indices_obj = detail::GetValue(indices_iterator);
-  const ::detail::json &values_obj = detail::GetValue(values_iterator);
+  const detail::json &indices_obj = detail::GetValue(indices_iterator);
+  const detail::json &values_obj = detail::GetValue(values_iterator);
 
   int indices_buffer_view = 0, indices_byte_offset = 0, component_type = 0;
   if (!ParseIntegerProperty(&indices_buffer_view, err, indices_obj,
@@ -4433,7 +4435,7 @@ static bool ParseSparseAccessor(Accessor *accessor, std::string *err,
   return true;
 }
 
-static bool ParseAccessor(Accessor *accessor, std::string *err, const ::detail::json &o,
+static bool ParseAccessor(Accessor *accessor, std::string *err, const detail::json &o,
                           bool store_original_json_for_extras_and_extensions) {
   int bufferView = -1;
   ParseIntegerProperty(&bufferView, err, o, "bufferView", false, "Accessor");
@@ -4518,13 +4520,13 @@ static bool ParseAccessor(Accessor *accessor, std::string *err, const ::detail::
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extensions", it)) {
         accessor->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extras", it)) {
         accessor->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
@@ -4532,7 +4534,7 @@ static bool ParseAccessor(Accessor *accessor, std::string *err, const ::detail::
   }
 
   // check if accessor has a "sparse" object:
-  ::detail::json_const_iterator iterator;
+  detail::json_const_iterator iterator;
   if (detail::FindMember(o, "sparse", iterator)) {
     // here this accessor has a "sparse" subobject
     return ParseSparseAccessor(accessor, err, detail::GetValue(iterator));
@@ -4734,7 +4736,7 @@ static bool ParseDracoExtension(Primitive *primitive, Model *model,
 #endif
 
 static bool ParsePrimitive(Primitive *primitive, Model *model, std::string *err,
-                           const ::detail::json &o,
+                           const detail::json &o,
                            bool store_original_json_for_extras_and_extensions) {
   int material = -1;
   ParseIntegerProperty(&material, err, o, "material", false);
@@ -4753,18 +4755,18 @@ static bool ParsePrimitive(Primitive *primitive, Model *model, std::string *err,
   }
 
   // Look for morph targets
-  ::detail::json_const_iterator targetsObject;
+  detail::json_const_iterator targetsObject;
   if (detail::FindMember(o, "targets", targetsObject) &&
       detail::IsArray(detail::GetValue(targetsObject))) {
     auto targetsObjectEnd = detail::ArrayEnd(detail::GetValue(targetsObject));
-    for (::detail::json_const_array_iterator i = detail::ArrayBegin(detail::GetValue(targetsObject));
+    for (detail::json_const_array_iterator i = detail::ArrayBegin(detail::GetValue(targetsObject));
          i != targetsObjectEnd; ++i) {
       std::map<std::string, int> targetAttribues;
 
-      const ::detail::json &dict = *i;
+      const detail::json &dict = *i;
       if (detail::IsObject(dict)) {
-        ::detail::json_const_iterator dictIt(detail::ObjectBegin(dict));
-        ::detail::json_const_iterator dictItEnd(detail::ObjectEnd(dict));
+        detail::json_const_iterator dictIt(detail::ObjectBegin(dict));
+        detail::json_const_iterator dictItEnd(detail::ObjectEnd(dict));
 
         for (; dictIt != dictItEnd; ++dictIt) {
           int iVal;
@@ -4781,13 +4783,13 @@ static bool ParsePrimitive(Primitive *primitive, Model *model, std::string *err,
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extensions", it)) {
         primitive->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extras", it)) {
         primitive->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
@@ -4807,16 +4809,16 @@ static bool ParsePrimitive(Primitive *primitive, Model *model, std::string *err,
   return true;
 }
 
-static bool ParseMesh(Mesh *mesh, Model *model, std::string *err, const ::detail::json &o,
+static bool ParseMesh(Mesh *mesh, Model *model, std::string *err, const detail::json &o,
                       bool store_original_json_for_extras_and_extensions) {
   ParseStringProperty(&mesh->name, err, o, "name", false);
 
   mesh->primitives.clear();
-  ::detail::json_const_iterator primObject;
+  detail::json_const_iterator primObject;
   if (detail::FindMember(o, "primitives", primObject) &&
       detail::IsArray(detail::GetValue(primObject))) {
-    ::detail::json_const_array_iterator primEnd = detail::ArrayEnd(detail::GetValue(primObject));
-    for (::detail::json_const_array_iterator i = detail::ArrayBegin(detail::GetValue(primObject));
+    detail::json_const_array_iterator primEnd = detail::ArrayEnd(detail::GetValue(primObject));
+    for (detail::json_const_array_iterator i = detail::ArrayBegin(detail::GetValue(primObject));
          i != primEnd; ++i) {
       Primitive primitive;
       if (ParsePrimitive(&primitive, model, err, *i,
@@ -4835,13 +4837,13 @@ static bool ParseMesh(Mesh *mesh, Model *model, std::string *err, const ::detail
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extensions", it)) {
         mesh->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extras", it)) {
         mesh->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
@@ -4851,7 +4853,7 @@ static bool ParseMesh(Mesh *mesh, Model *model, std::string *err, const ::detail
   return true;
 }
 
-static bool ParseNode(Node *node, std::string *err, const ::detail::json &o,
+static bool ParseNode(Node *node, std::string *err, const detail::json &o,
                       bool store_original_json_for_extras_and_extensions) {
   ParseStringProperty(&node->name, err, o, "name", false);
 
@@ -4884,13 +4886,13 @@ static bool ParseNode(Node *node, std::string *err, const ::detail::json &o,
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extensions", it)) {
         node->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extras", it)) {
         node->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
@@ -4901,7 +4903,7 @@ static bool ParseNode(Node *node, std::string *err, const ::detail::json &o,
 }
 
 static bool ParsePbrMetallicRoughness(
-    PbrMetallicRoughness *pbr, std::string *err, const ::detail::json &o,
+    PbrMetallicRoughness *pbr, std::string *err, const detail::json &o,
     bool store_original_json_for_extras_and_extensions) {
   if (pbr == nullptr) {
     return false;
@@ -4923,7 +4925,7 @@ static bool ParsePbrMetallicRoughness(
   }
 
   {
-    ::detail::json_const_iterator it;
+    detail::json_const_iterator it;
     if (detail::FindMember(o, "baseColorTexture", it)) {
       ParseTextureInfo(&pbr->baseColorTexture, err, detail::GetValue(it),
                        store_original_json_for_extras_and_extensions);
@@ -4931,7 +4933,7 @@ static bool ParsePbrMetallicRoughness(
   }
 
   {
-    ::detail::json_const_iterator it;
+    detail::json_const_iterator it;
     if (detail::FindMember(o, "metallicRoughnessTexture", it)) {
       ParseTextureInfo(&pbr->metallicRoughnessTexture, err, detail::GetValue(it),
                        store_original_json_for_extras_and_extensions);
@@ -4946,13 +4948,13 @@ static bool ParsePbrMetallicRoughness(
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extensions", it)) {
         pbr->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extras", it)) {
         pbr->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
@@ -4962,7 +4964,7 @@ static bool ParsePbrMetallicRoughness(
   return true;
 }
 
-static bool ParseMaterial(Material *material, std::string *err, const ::detail::json &o,
+static bool ParseMaterial(Material *material, std::string *err, const detail::json &o,
                           bool store_original_json_for_extras_and_extensions) {
   ParseStringProperty(&material->name, err, o, "name", /* required */ false);
 
@@ -4991,7 +4993,7 @@ static bool ParseMaterial(Material *material, std::string *err, const ::detail::
                        /* required */ false);
 
   {
-    ::detail::json_const_iterator it;
+    detail::json_const_iterator it;
     if (detail::FindMember(o, "pbrMetallicRoughness", it)) {
       ParsePbrMetallicRoughness(&material->pbrMetallicRoughness, err,
                                 detail::GetValue(it),
@@ -5000,7 +5002,7 @@ static bool ParseMaterial(Material *material, std::string *err, const ::detail::
   }
 
   {
-    ::detail::json_const_iterator it;
+    detail::json_const_iterator it;
     if (detail::FindMember(o, "normalTexture", it)) {
       ParseNormalTextureInfo(&material->normalTexture, err, detail::GetValue(it),
                              store_original_json_for_extras_and_extensions);
@@ -5008,7 +5010,7 @@ static bool ParseMaterial(Material *material, std::string *err, const ::detail::
   }
 
   {
-    ::detail::json_const_iterator it;
+    detail::json_const_iterator it;
     if (detail::FindMember(o, "occlusionTexture", it)) {
       ParseOcclusionTextureInfo(&material->occlusionTexture, err, detail::GetValue(it),
                                 store_original_json_for_extras_and_extensions);
@@ -5016,7 +5018,7 @@ static bool ParseMaterial(Material *material, std::string *err, const ::detail::
   }
 
   {
-    ::detail::json_const_iterator it;
+    detail::json_const_iterator it;
     if (detail::FindMember(o, "emissiveTexture", it)) {
       ParseTextureInfo(&material->emissiveTexture, err, detail::GetValue(it),
                        store_original_json_for_extras_and_extensions);
@@ -5031,17 +5033,17 @@ static bool ParseMaterial(Material *material, std::string *err, const ::detail::
   material->values.clear();
   material->additionalValues.clear();
 
-  ::detail::json_const_iterator it(detail::ObjectBegin(o));
-  ::detail::json_const_iterator itEnd(detail::ObjectEnd(o));
+  detail::json_const_iterator it(detail::ObjectBegin(o));
+  detail::json_const_iterator itEnd(detail::ObjectEnd(o));
 
   for (; it != itEnd; ++it) {
     std::string key(detail::GetKey(it));
     if (key == "pbrMetallicRoughness") {
       if (detail::IsObject(detail::GetValue(it))) {
-        const ::detail::json &values_object = detail::GetValue(it);
+        const detail::json &values_object = detail::GetValue(it);
 
-        ::detail::json_const_iterator itVal(detail::ObjectBegin(values_object));
-        ::detail::json_const_iterator itValEnd(detail::ObjectEnd(values_object));
+        detail::json_const_iterator itVal(detail::ObjectBegin(values_object));
+        detail::json_const_iterator itValEnd(detail::ObjectEnd(values_object));
 
         for (; itVal != itValEnd; ++itVal) {
           Parameter param;
@@ -5071,13 +5073,13 @@ static bool ParseMaterial(Material *material, std::string *err, const ::detail::
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      ::detail::json_const_iterator eit;
+      detail::json_const_iterator eit;
       if (detail::FindMember(o, "extensions", eit)) {
         material->extensions_json_string = detail::JsonToString(detail::GetValue(eit));
       }
     }
     {
-      ::detail::json_const_iterator eit;
+      detail::json_const_iterator eit;
       if (detail::FindMember(o, "extras", eit)) {
         material->extras_json_string = detail::JsonToString(detail::GetValue(eit));
       }
@@ -5088,7 +5090,7 @@ static bool ParseMaterial(Material *material, std::string *err, const ::detail::
 }
 
 static bool ParseAnimationChannel(
-    AnimationChannel *channel, std::string *err, const ::detail::json &o,
+    AnimationChannel *channel, std::string *err, const detail::json &o,
     bool store_original_json_for_extras_and_extensions) {
   int samplerIndex = -1;
   int targetIndex = -1;
@@ -5100,9 +5102,9 @@ static bool ParseAnimationChannel(
     return false;
   }
 
-  ::detail::json_const_iterator targetIt;
+  detail::json_const_iterator targetIt;
   if (detail::FindMember(o, "target", targetIt) && detail::IsObject(detail::GetValue(targetIt))) {
-    const ::detail::json &target_object = detail::GetValue(targetIt);
+    const detail::json &target_object = detail::GetValue(targetIt);
 
     ParseIntegerProperty(&targetIndex, err, target_object, "node", false);
 
@@ -5115,7 +5117,7 @@ static bool ParseAnimationChannel(
     }
     ParseExtensionsProperty(&channel->target_extensions, err, target_object);
     if (store_original_json_for_extras_and_extensions) {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(target_object, "extensions", it)) {
         channel->target_extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
@@ -5130,13 +5132,13 @@ static bool ParseAnimationChannel(
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extensions", it)) {
         channel->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extras", it)) {
         channel->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
@@ -5147,14 +5149,14 @@ static bool ParseAnimationChannel(
 }
 
 static bool ParseAnimation(Animation *animation, std::string *err,
-                           const ::detail::json &o,
+                           const detail::json &o,
                            bool store_original_json_for_extras_and_extensions) {
   {
-    ::detail::json_const_iterator channelsIt;
+    detail::json_const_iterator channelsIt;
     if (detail::FindMember(o, "channels", channelsIt) &&
         detail::IsArray(detail::GetValue(channelsIt))) {
-      ::detail::json_const_array_iterator channelEnd = detail::ArrayEnd(detail::GetValue(channelsIt));
-      for (::detail::json_const_array_iterator i = detail::ArrayBegin(detail::GetValue(channelsIt));
+      detail::json_const_array_iterator channelEnd = detail::ArrayEnd(detail::GetValue(channelsIt));
+      for (detail::json_const_array_iterator i = detail::ArrayBegin(detail::GetValue(channelsIt));
            i != channelEnd; ++i) {
         AnimationChannel channel;
         if (ParseAnimationChannel(
@@ -5168,15 +5170,15 @@ static bool ParseAnimation(Animation *animation, std::string *err,
   }
 
   {
-    ::detail::json_const_iterator samplerIt;
+    detail::json_const_iterator samplerIt;
     if (detail::FindMember(o, "samplers", samplerIt) && detail::IsArray(detail::GetValue(samplerIt))) {
-      const ::detail::json &sampler_array = detail::GetValue(samplerIt);
+      const detail::json &sampler_array = detail::GetValue(samplerIt);
 
-      ::detail::json_const_array_iterator it = detail::ArrayBegin(sampler_array);
-      ::detail::json_const_array_iterator itEnd = detail::ArrayEnd(sampler_array);
+      detail::json_const_array_iterator it = detail::ArrayBegin(sampler_array);
+      detail::json_const_array_iterator itEnd = detail::ArrayEnd(sampler_array);
 
       for (; it != itEnd; ++it) {
-        const ::detail::json &s = *it;
+        const detail::json &s = *it;
 
         AnimationSampler sampler;
         int inputIndex = -1;
@@ -5202,13 +5204,13 @@ static bool ParseAnimation(Animation *animation, std::string *err,
 
         if (store_original_json_for_extras_and_extensions) {
           {
-            ::detail::json_const_iterator eit;
+            detail::json_const_iterator eit;
             if (detail::FindMember(o, "extensions", eit)) {
               sampler.extensions_json_string = detail::JsonToString(detail::GetValue(eit));
             }
           }
           {
-            ::detail::json_const_iterator eit;
+            detail::json_const_iterator eit;
             if (detail::FindMember(o, "extras", eit)) {
               sampler.extras_json_string = detail::JsonToString(detail::GetValue(eit));
             }
@@ -5227,13 +5229,13 @@ static bool ParseAnimation(Animation *animation, std::string *err,
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extensions", it)) {
         animation->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extras", it)) {
         animation->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
@@ -5243,7 +5245,7 @@ static bool ParseAnimation(Animation *animation, std::string *err,
   return true;
 }
 
-static bool ParseSampler(Sampler *sampler, std::string *err, const ::detail::json &o,
+static bool ParseSampler(Sampler *sampler, std::string *err, const detail::json &o,
                          bool store_original_json_for_extras_and_extensions) {
   ParseStringProperty(&sampler->name, err, o, "name", false);
 
@@ -5273,13 +5275,13 @@ static bool ParseSampler(Sampler *sampler, std::string *err, const ::detail::jso
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extensions", it)) {
         sampler->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extras", it)) {
         sampler->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
@@ -5289,7 +5291,7 @@ static bool ParseSampler(Sampler *sampler, std::string *err, const ::detail::jso
   return true;
 }
 
-static bool ParseSkin(Skin *skin, std::string *err, const ::detail::json &o,
+static bool ParseSkin(Skin *skin, std::string *err, const detail::json &o,
                       bool store_original_json_for_extras_and_extensions) {
   ParseStringProperty(&skin->name, err, o, "name", false, "Skin");
 
@@ -5312,13 +5314,13 @@ static bool ParseSkin(Skin *skin, std::string *err, const ::detail::json &o,
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extensions", it)) {
         skin->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extras", it)) {
         skin->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
@@ -5329,7 +5331,7 @@ static bool ParseSkin(Skin *skin, std::string *err, const ::detail::json &o,
 }
 
 static bool ParsePerspectiveCamera(
-    PerspectiveCamera *camera, std::string *err, const ::detail::json &o,
+    PerspectiveCamera *camera, std::string *err, const detail::json &o,
     bool store_original_json_for_extras_and_extensions) {
   double yfov = 0.0;
   if (!ParseNumberProperty(&yfov, err, o, "yfov", true, "OrthographicCamera")) {
@@ -5359,13 +5361,13 @@ static bool ParsePerspectiveCamera(
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extensions", it)) {
         camera->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extras", it)) {
         camera->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
@@ -5377,7 +5379,7 @@ static bool ParsePerspectiveCamera(
   return true;
 }
 
-static bool ParseSpotLight(SpotLight *light, std::string *err, const ::detail::json &o,
+static bool ParseSpotLight(SpotLight *light, std::string *err, const detail::json &o,
                            bool store_original_json_for_extras_and_extensions) {
   ParseNumberProperty(&light->innerConeAngle, err, o, "innerConeAngle", false);
   ParseNumberProperty(&light->outerConeAngle, err, o, "outerConeAngle", false);
@@ -5387,13 +5389,13 @@ static bool ParseSpotLight(SpotLight *light, std::string *err, const ::detail::j
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extensions", it)) {
         light->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extras", it)) {
         light->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
@@ -5406,7 +5408,7 @@ static bool ParseSpotLight(SpotLight *light, std::string *err, const ::detail::j
 }
 
 static bool ParseOrthographicCamera(
-    OrthographicCamera *camera, std::string *err, const ::detail::json &o,
+    OrthographicCamera *camera, std::string *err, const detail::json &o,
     bool store_original_json_for_extras_and_extensions) {
   double xmag = 0.0;
   if (!ParseNumberProperty(&xmag, err, o, "xmag", true, "OrthographicCamera")) {
@@ -5434,13 +5436,13 @@ static bool ParseOrthographicCamera(
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extensions", it)) {
         camera->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extras", it)) {
         camera->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
@@ -5457,14 +5459,14 @@ static bool ParseOrthographicCamera(
   return true;
 }
 
-static bool ParseCamera(Camera *camera, std::string *err, const ::detail::json &o,
+static bool ParseCamera(Camera *camera, std::string *err, const detail::json &o,
                         bool store_original_json_for_extras_and_extensions) {
   if (!ParseStringProperty(&camera->type, err, o, "type", true, "Camera")) {
     return false;
   }
 
   if (camera->type.compare("orthographic") == 0) {
-    ::detail::json_const_iterator orthoIt;
+    detail::json_const_iterator orthoIt;
     if (!detail::FindMember(o, "orthographic", orthoIt)) {
       if (err) {
         std::stringstream ss;
@@ -5474,7 +5476,7 @@ static bool ParseCamera(Camera *camera, std::string *err, const ::detail::json &
       return false;
     }
 
-    const ::detail::json &v = detail::GetValue(orthoIt);
+    const detail::json &v = detail::GetValue(orthoIt);
     if (!detail::IsObject(v)) {
       if (err) {
         std::stringstream ss;
@@ -5490,7 +5492,7 @@ static bool ParseCamera(Camera *camera, std::string *err, const ::detail::json &
       return false;
     }
   } else if (camera->type.compare("perspective") == 0) {
-    ::detail::json_const_iterator perspIt;
+    detail::json_const_iterator perspIt;
     if (!detail::FindMember(o, "perspective", perspIt)) {
       if (err) {
         std::stringstream ss;
@@ -5500,7 +5502,7 @@ static bool ParseCamera(Camera *camera, std::string *err, const ::detail::json &
       return false;
     }
 
-    const ::detail::json &v = detail::GetValue(perspIt);
+    const detail::json &v = detail::GetValue(perspIt);
     if (!detail::IsObject(v)) {
       if (err) {
         std::stringstream ss;
@@ -5532,13 +5534,13 @@ static bool ParseCamera(Camera *camera, std::string *err, const ::detail::json &
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extensions", it)) {
         camera->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extras", it)) {
         camera->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
@@ -5548,14 +5550,14 @@ static bool ParseCamera(Camera *camera, std::string *err, const ::detail::json &
   return true;
 }
 
-static bool ParseLight(Light *light, std::string *err, const ::detail::json &o,
+static bool ParseLight(Light *light, std::string *err, const detail::json &o,
                        bool store_original_json_for_extras_and_extensions) {
   if (!ParseStringProperty(&light->type, err, o, "type", true)) {
     return false;
   }
 
   if (light->type == "spot") {
-    ::detail::json_const_iterator spotIt;
+    detail::json_const_iterator spotIt;
     if (!detail::FindMember(o, "spot", spotIt)) {
       if (err) {
         std::stringstream ss;
@@ -5565,7 +5567,7 @@ static bool ParseLight(Light *light, std::string *err, const ::detail::json &o,
       return false;
     }
 
-    const ::detail::json &v = detail::GetValue(spotIt);
+    const detail::json &v = detail::GetValue(spotIt);
     if (!detail::IsObject(v)) {
       if (err) {
         std::stringstream ss;
@@ -5590,13 +5592,13 @@ static bool ParseLight(Light *light, std::string *err, const ::detail::json &o,
 
   if (store_original_json_for_extras_and_extensions) {
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extensions", it)) {
         light->extensions_json_string = detail::JsonToString(detail::GetValue(it));
       }
     }
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extras", it)) {
         light->extras_json_string = detail::JsonToString(detail::GetValue(it));
       }
@@ -5618,13 +5620,13 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
     return false;
   }
 
-  ::detail::JsonDocument v;
+  detail::JsonDocument v;
 
 #if (defined(__cpp_exceptions) || defined(__EXCEPTIONS) || \
      defined(_CPPUNWIND)) &&                               \
     !defined(TINYGLTF_NOEXCEPTION)
   try {
-    ::detail::JsonParse(v, json_str, json_str_length, true);
+    detail::JsonParse(v, json_str, json_str_length, true);
 
   } catch (const std::exception &e) {
     if (err) {
@@ -5634,7 +5636,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
   }
 #else
   {
-    ::detail::JsonParse(v, json_str, json_str_length);
+    detail::JsonParse(v, json_str, json_str_length);
 
     if (!detail::IsObject(v)) {
       // Assume parsing was failed.
@@ -5656,10 +5658,10 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
   {
     bool version_found = false;
-    ::detail::json_const_iterator it;
+    detail::json_const_iterator it;
     if (detail::FindMember(v, "asset", it) && detail::IsObject(detail::GetValue(it))) {
       auto &itObj = detail::GetValue(it);
-      ::detail::json_const_iterator version_it;
+      detail::json_const_iterator version_it;
       std::string versionStr;
       if (detail::FindMember(itObj, "version", version_it) &&
           detail::GetString(detail::GetValue(version_it), versionStr)) {
@@ -5679,8 +5681,8 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
   // scene is not mandatory.
   // FIXME Maybe a better way to handle it than removing the code
 
-  auto IsArrayMemberPresent = [](const ::detail::json &_v, const char *name) -> bool {
-    ::detail::json_const_iterator it;
+  auto IsArrayMemberPresent = [](const detail::json &_v, const char *name) -> bool {
+    detail::json_const_iterator it;
     return detail::FindMember(_v, name, it) && detail::IsArray(detail::GetValue(it));
   };
 
@@ -5746,9 +5748,9 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
   // 1. Parse Asset
   {
-    ::detail::json_const_iterator it;
+    detail::json_const_iterator it;
     if (detail::FindMember(v, "asset", it) && detail::IsObject(detail::GetValue(it))) {
-      const ::detail::json &root = detail::GetValue(it);
+      const detail::json &root = detail::GetValue(it);
 
       ParseAsset(&model->asset, err, root,
                  store_original_json_for_extras_and_extensions_);
@@ -5756,19 +5758,19 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
   }
 
 #ifdef TINYGLTF_USE_CPP14
-  auto ForEachInArray = [](const ::detail::json &_v, const char *member,
+  auto ForEachInArray = [](const detail::json &_v, const char *member,
                            const auto &cb) -> bool
 #else
   // The std::function<> implementation can be less efficient because it will
   // allocate heap when the size of the captured lambda is above 16 bytes with
   // clang and gcc, but it does not require C++14.
-  auto ForEachInArray = [](const ::detail::json &_v, const char *member,
-                           const std::function<bool(const ::detail::json &)> &cb) -> bool
+  auto ForEachInArray = [](const detail::json &_v, const char *member,
+                           const std::function<bool(const detail::json &)> &cb) -> bool
 #endif
   {
-    ::detail::json_const_iterator itm;
+    detail::json_const_iterator itm;
     if (detail::FindMember(_v, member, itm) && detail::IsArray(detail::GetValue(itm))) {
-      const ::detail::json &root = detail::GetValue(itm);
+      const detail::json &root = detail::GetValue(itm);
       auto it = detail::ArrayBegin(root);
       auto end = detail::ArrayEnd(root);
       for (; it != end; ++it) {
@@ -5780,7 +5782,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
   // 2. Parse extensionUsed
   {
-    ForEachInArray(v, "extensionsUsed", [&](const ::detail::json &o) {
+    ForEachInArray(v, "extensionsUsed", [&](const detail::json &o) {
       std::string str;
       detail::GetString(o, str);
       model->extensionsUsed.emplace_back(std::move(str));
@@ -5789,7 +5791,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
   }
 
   {
-    ForEachInArray(v, "extensionsRequired", [&](const ::detail::json &o) {
+    ForEachInArray(v, "extensionsRequired", [&](const detail::json &o) {
       std::string str;
       detail::GetString(o, str);
       model->extensionsRequired.emplace_back(std::move(str));
@@ -5799,7 +5801,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
   // 3. Parse Buffer
   {
-    bool success = ForEachInArray(v, "buffers", [&](const ::detail::json &o) {
+    bool success = ForEachInArray(v, "buffers", [&](const detail::json &o) {
       if (!detail::IsObject(o)) {
         if (err) {
           (*err) += "`buffers' does not contain an JSON object.";
@@ -5823,7 +5825,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
   }
   // 4. Parse BufferView
   {
-    bool success = ForEachInArray(v, "bufferViews", [&](const ::detail::json &o) {
+    bool success = ForEachInArray(v, "bufferViews", [&](const detail::json &o) {
       if (!detail::IsObject(o)) {
         if (err) {
           (*err) += "`bufferViews' does not contain an JSON object.";
@@ -5847,7 +5849,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
   // 5. Parse Accessor
   {
-    bool success = ForEachInArray(v, "accessors", [&](const ::detail::json &o) {
+    bool success = ForEachInArray(v, "accessors", [&](const detail::json &o) {
       if (!detail::IsObject(o)) {
         if (err) {
           (*err) += "`accessors' does not contain an JSON object.";
@@ -5871,7 +5873,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
   // 6. Parse Mesh
   {
-    bool success = ForEachInArray(v, "meshes", [&](const ::detail::json &o) {
+    bool success = ForEachInArray(v, "meshes", [&](const detail::json &o) {
       if (!detail::IsObject(o)) {
         if (err) {
           (*err) += "`meshes' does not contain an JSON object.";
@@ -5954,7 +5956,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
   // 7. Parse Node
   {
-    bool success = ForEachInArray(v, "nodes", [&](const ::detail::json &o) {
+    bool success = ForEachInArray(v, "nodes", [&](const detail::json &o) {
       if (!detail::IsObject(o)) {
         if (err) {
           (*err) += "`nodes' does not contain an JSON object.";
@@ -5978,7 +5980,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
   // 8. Parse scenes.
   {
-    bool success = ForEachInArray(v, "scenes", [&](const ::detail::json &o) {
+    bool success = ForEachInArray(v, "scenes", [&](const detail::json &o) {
       if (!detail::IsObject(o)) {
         if (err) {
           (*err) += "`scenes' does not contain an JSON object.";
@@ -5998,13 +6000,13 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
       if (store_original_json_for_extras_and_extensions_) {
         {
-          ::detail::json_const_iterator it;
+          detail::json_const_iterator it;
           if (detail::FindMember(o, "extensions", it)) {
             scene.extensions_json_string = detail::JsonToString(detail::GetValue(it));
           }
         }
         {
-          ::detail::json_const_iterator it;
+          detail::json_const_iterator it;
           if (detail::FindMember(o, "extras", it)) {
             scene.extras_json_string = detail::JsonToString(detail::GetValue(it));
           }
@@ -6022,7 +6024,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
   // 9. Parse default scenes.
   {
-    ::detail::json_const_iterator rootIt;
+    detail::json_const_iterator rootIt;
     int iVal;
     if (detail::FindMember(v, "scene", rootIt) && detail::GetInt(detail::GetValue(rootIt), iVal)) {
       model->defaultScene = iVal;
@@ -6031,7 +6033,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
   // 10. Parse Material
   {
-    bool success = ForEachInArray(v, "materials", [&](const ::detail::json &o) {
+    bool success = ForEachInArray(v, "materials", [&](const detail::json &o) {
       if (!detail::IsObject(o)) {
         if (err) {
           (*err) += "`materials' does not contain an JSON object.";
@@ -6070,7 +6072,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
   {
     int idx = 0;
-    bool success = ForEachInArray(v, "images", [&](const ::detail::json &o) {
+    bool success = ForEachInArray(v, "images", [&](const detail::json &o) {
       if (!detail::IsObject(o)) {
         if (err) {
           (*err) += "image[" + std::to_string(idx) + "] is not a JSON object.";
@@ -6137,7 +6139,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
   // 12. Parse Texture
   {
-    bool success = ForEachInArray(v, "textures", [&](const ::detail::json &o) {
+    bool success = ForEachInArray(v, "textures", [&](const detail::json &o) {
       if (!detail::IsObject(o)) {
         if (err) {
           (*err) += "`textures' does not contain an JSON object.";
@@ -6162,7 +6164,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
   // 13. Parse Animation
   {
-    bool success = ForEachInArray(v, "animations", [&](const ::detail::json &o) {
+    bool success = ForEachInArray(v, "animations", [&](const detail::json &o) {
       if (!detail::IsObject(o)) {
         if (err) {
           (*err) += "`animations' does not contain an JSON object.";
@@ -6186,7 +6188,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
   // 14. Parse Skin
   {
-    bool success = ForEachInArray(v, "skins", [&](const ::detail::json &o) {
+    bool success = ForEachInArray(v, "skins", [&](const detail::json &o) {
       if (!detail::IsObject(o)) {
         if (err) {
           (*err) += "`skins' does not contain an JSON object.";
@@ -6210,7 +6212,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
   // 15. Parse Sampler
   {
-    bool success = ForEachInArray(v, "samplers", [&](const ::detail::json &o) {
+    bool success = ForEachInArray(v, "samplers", [&](const detail::json &o) {
       if (!detail::IsObject(o)) {
         if (err) {
           (*err) += "`samplers' does not contain an JSON object.";
@@ -6234,7 +6236,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
   // 16. Parse Camera
   {
-    bool success = ForEachInArray(v, "cameras", [&](const ::detail::json &o) {
+    bool success = ForEachInArray(v, "cameras", [&](const detail::json &o) {
       if (!detail::IsObject(o)) {
         if (err) {
           (*err) += "`cameras' does not contain an JSON object.";
@@ -6261,20 +6263,20 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
 
   // 18. Specific extension implementations
   {
-    ::detail::json_const_iterator rootIt;
+    detail::json_const_iterator rootIt;
     if (detail::FindMember(v, "extensions", rootIt) && detail::IsObject(detail::GetValue(rootIt))) {
-      const ::detail::json &root = detail::GetValue(rootIt);
+      const detail::json &root = detail::GetValue(rootIt);
 
-      ::detail::json_const_iterator it(detail::ObjectBegin(root));
-      ::detail::json_const_iterator itEnd(detail::ObjectEnd(root));
+      detail::json_const_iterator it(detail::ObjectBegin(root));
+      detail::json_const_iterator itEnd(detail::ObjectEnd(root));
       for (; it != itEnd; ++it) {
         // parse KHR_lights_punctual extension
         std::string key(detail::GetKey(it));
         if ((key == "KHR_lights_punctual") && detail::IsObject(detail::GetValue(it))) {
-          const ::detail::json &object = detail::GetValue(it);
-          ::detail::json_const_iterator itLight;
+          const detail::json &object = detail::GetValue(it);
+          detail::json_const_iterator itLight;
           if (detail::FindMember(object, "lights", itLight)) {
-            const ::detail::json &lights = detail::GetValue(itLight);
+            const detail::json &lights = detail::GetValue(itLight);
             if (!detail::IsArray(lights)) {
               continue;
             }
@@ -6553,42 +6555,42 @@ bool TinyGLTF::LoadBinaryFromFile(Model *model, std::string *err,
 // GLTF Serialization
 ///////////////////////
 namespace detail {
-::detail::json JsonFromString(const char *s) {
+detail::json JsonFromString(const char *s) {
 #ifdef TINYGLTF_USE_RAPIDJSON
-  return ::detail::json(s, ::detail::GetAllocator());
+  return detail::json(s, detail::GetAllocator());
 #else
-  return ::detail::json(s);
+  return detail::json(s);
 #endif
 }
 
-void JsonAssign(::detail::json &dest, const ::detail::json &src) {
+void JsonAssign(detail::json &dest, const detail::json &src) {
 #ifdef TINYGLTF_USE_RAPIDJSON
-  dest.CopyFrom(src, ::detail::GetAllocator());
+  dest.CopyFrom(src, detail::GetAllocator());
 #else
   dest = src;
 #endif
 }
 
-void JsonAddMember(::detail::json &o, const char *key, ::detail::json &&value) {
+void JsonAddMember(detail::json &o, const char *key, detail::json &&value) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   if (!o.IsObject()) {
     o.SetObject();
   }
-  o.AddMember(::detail::json(key, ::detail::GetAllocator()), std::move(value), ::detail::GetAllocator());
+  o.AddMember(detail::json(key, detail::GetAllocator()), std::move(value), detail::GetAllocator());
 #else
   o[key] = std::move(value);
 #endif
 }
 
-void JsonPushBack(::detail::json &o, ::detail::json &&value) {
+void JsonPushBack(detail::json &o, detail::json &&value) {
 #ifdef TINYGLTF_USE_RAPIDJSON
-  o.PushBack(std::move(value), ::detail::GetAllocator());
+  o.PushBack(std::move(value), detail::GetAllocator());
 #else
   o.push_back(std::move(value));
 #endif
 }
 
-bool JsonIsNull(const ::detail::json &o) {
+bool JsonIsNull(const detail::json &o) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   return o.IsNull();
 #else
@@ -6596,7 +6598,7 @@ bool JsonIsNull(const ::detail::json &o) {
 #endif
 }
 
-void JsonSetObject(::detail::json &o) {
+void JsonSetObject(detail::json &o) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   o.SetObject();
 #else
@@ -6604,57 +6606,57 @@ void JsonSetObject(::detail::json &o) {
 #endif
 }
 
-void JsonReserveArray(::detail::json &o, size_t s) {
+void JsonReserveArray(detail::json &o, size_t s) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   o.SetArray();
-  o.Reserve(static_cast<rapidjson::SizeType>(s), ::detail::GetAllocator());
+  o.Reserve(static_cast<rapidjson::SizeType>(s), detail::GetAllocator());
 #endif
   (void)(o);
   (void)(s);
 }
 }  // namespace
 
-// typedef std::pair<std::string, ::detail::json> json_object_pair;
+// typedef std::pair<std::string, detail::json> json_object_pair;
 
 template <typename T>
 static void SerializeNumberProperty(const std::string &key, T number,
-                                    ::detail::json &obj) {
+                                    detail::json &obj) {
   // obj.insert(
-  //    json_object_pair(key, ::detail::json(static_cast<double>(number))));
+  //    json_object_pair(key, detail::json(static_cast<double>(number))));
   // obj[key] = static_cast<double>(number);
-  detail::JsonAddMember(obj, key.c_str(), ::detail::json(number));
+  detail::JsonAddMember(obj, key.c_str(), detail::json(number));
 }
 
 #ifdef TINYGLTF_USE_RAPIDJSON
 template <>
-void SerializeNumberProperty(const std::string &key, size_t number, ::detail::json &obj) {
-  detail::JsonAddMember(obj, key.c_str(), ::detail::json(static_cast<uint64_t>(number)));
+void SerializeNumberProperty(const std::string &key, size_t number, detail::json &obj) {
+  detail::JsonAddMember(obj, key.c_str(), detail::json(static_cast<uint64_t>(number)));
 }
 #endif
 
 template <typename T>
 static void SerializeNumberArrayProperty(const std::string &key,
                                          const std::vector<T> &value,
-                                         ::detail::json &obj) {
+                                         detail::json &obj) {
   if (value.empty()) return;
 
-  ::detail::json ary;
+  detail::json ary;
   detail::JsonReserveArray(ary, value.size());
   for (const auto &s : value) {
-    detail::JsonPushBack(ary, ::detail::json(s));
+    detail::JsonPushBack(ary, detail::json(s));
   }
   detail::JsonAddMember(obj, key.c_str(), std::move(ary));
 }
 
 static void SerializeStringProperty(const std::string &key,
-                                    const std::string &value, ::detail::json &obj) {
+                                    const std::string &value, detail::json &obj) {
   detail::JsonAddMember(obj, key.c_str(), detail::JsonFromString(value.c_str()));
 }
 
 static void SerializeStringArrayProperty(const std::string &key,
                                          const std::vector<std::string> &value,
-                                         ::detail::json &obj) {
-  ::detail::json ary;
+                                         detail::json &obj) {
+  detail::json ary;
   detail::JsonReserveArray(ary, value.size());
   for (auto &s : value) {
     detail::JsonPushBack(ary, detail::JsonFromString(s.c_str()));
@@ -6662,8 +6664,8 @@ static void SerializeStringArrayProperty(const std::string &key,
   detail::JsonAddMember(obj, key.c_str(), std::move(ary));
 }
 
-static bool ValueToJson(const Value &value, ::detail::json *ret) {
-  ::detail::json obj;
+static bool ValueToJson(const Value &value, detail::json *ret) {
+  detail::json obj;
 #ifdef TINYGLTF_USE_RAPIDJSON
   switch (value.Type()) {
     case REAL_TYPE:
@@ -6676,33 +6678,33 @@ static bool ValueToJson(const Value &value, ::detail::json *ret) {
       obj.SetBool(value.Get<bool>());
       break;
     case STRING_TYPE:
-      obj.SetString(value.Get<std::string>().c_str(), ::detail::GetAllocator());
+      obj.SetString(value.Get<std::string>().c_str(), detail::GetAllocator());
       break;
     case ARRAY_TYPE: {
       obj.SetArray();
       obj.Reserve(static_cast<rapidjson::SizeType>(value.ArrayLen()),
-                  ::detail::GetAllocator());
+                  detail::GetAllocator());
       for (unsigned int i = 0; i < value.ArrayLen(); ++i) {
         Value elementValue = value.Get(int(i));
-        ::detail::json elementJson;
+        detail::json elementJson;
         if (ValueToJson(value.Get(int(i)), &elementJson))
-          obj.PushBack(std::move(elementJson), ::detail::GetAllocator());
+          obj.PushBack(std::move(elementJson), detail::GetAllocator());
       }
       break;
     }
     case BINARY_TYPE:
       // TODO
-      // obj = ::detail::json(value.Get<std::vector<unsigned char>>());
+      // obj = detail::json(value.Get<std::vector<unsigned char>>());
       return false;
       break;
     case OBJECT_TYPE: {
       obj.SetObject();
       Value::Object objMap = value.Get<Value::Object>();
       for (auto &it : objMap) {
-        ::detail::json elementJson;
+        detail::json elementJson;
         if (ValueToJson(it.second, &elementJson)) {
-          obj.AddMember(::detail::json(it.first.c_str(), ::detail::GetAllocator()),
-                        std::move(elementJson), ::detail::GetAllocator());
+          obj.AddMember(detail::json(it.first.c_str(), detail::GetAllocator()),
+                        std::move(elementJson), detail::GetAllocator());
         }
       }
       break;
@@ -6714,21 +6716,21 @@ static bool ValueToJson(const Value &value, ::detail::json *ret) {
 #else
   switch (value.Type()) {
     case REAL_TYPE:
-      obj = ::detail::json(value.Get<double>());
+      obj = detail::json(value.Get<double>());
       break;
     case INT_TYPE:
-      obj = ::detail::json(value.Get<int>());
+      obj = detail::json(value.Get<int>());
       break;
     case BOOL_TYPE:
-      obj = ::detail::json(value.Get<bool>());
+      obj = detail::json(value.Get<bool>());
       break;
     case STRING_TYPE:
-      obj = ::detail::json(value.Get<std::string>());
+      obj = detail::json(value.Get<std::string>());
       break;
     case ARRAY_TYPE: {
       for (unsigned int i = 0; i < value.ArrayLen(); ++i) {
         Value elementValue = value.Get(int(i));
-        ::detail::json elementJson;
+        detail::json elementJson;
         if (ValueToJson(value.Get(int(i)), &elementJson))
           obj.push_back(elementJson);
       }
@@ -6742,7 +6744,7 @@ static bool ValueToJson(const Value &value, ::detail::json *ret) {
     case OBJECT_TYPE: {
       Value::Object objMap = value.Get<Value::Object>();
       for (auto &it : objMap) {
-        ::detail::json elementJson;
+        detail::json elementJson;
         if (ValueToJson(it.second, &elementJson)) obj[it.first] = elementJson;
       }
       break;
@@ -6757,15 +6759,15 @@ static bool ValueToJson(const Value &value, ::detail::json *ret) {
 }
 
 static void SerializeValue(const std::string &key, const Value &value,
-                           ::detail::json &obj) {
-  ::detail::json ret;
+                           detail::json &obj) {
+  detail::json ret;
   if (ValueToJson(value, &ret)) {
     detail::JsonAddMember(obj, key.c_str(), std::move(ret));
   }
 }
 
 static void SerializeGltfBufferData(const std::vector<unsigned char> &data,
-                                    ::detail::json &o) {
+                                    detail::json &o) {
   std::string header = "data:application/octet-stream;base64,";
   if (data.size() > 0) {
     std::string encodedData =
@@ -6811,14 +6813,14 @@ static bool SerializeGltfBufferData(const std::vector<unsigned char> &data,
 }
 
 #if 0  // FIXME(syoyo): not used. will be removed in the future release.
-static void SerializeParameterMap(ParameterMap &param, ::detail::json &o) {
+static void SerializeParameterMap(ParameterMap &param, detail::json &o) {
   for (ParameterMap::iterator paramIt = param.begin(); paramIt != param.end();
        ++paramIt) {
     if (paramIt->second.number_array.size()) {
       SerializeNumberArrayProperty<double>(paramIt->first,
                                            paramIt->second.number_array, o);
     } else if (paramIt->second.json_double_value.size()) {
-      ::detail::json json_double_value;
+      detail::json json_double_value;
       for (std::map<std::string, double>::iterator it =
                paramIt->second.json_double_value.begin();
            it != paramIt->second.json_double_value.end(); ++it) {
@@ -6841,14 +6843,14 @@ static void SerializeParameterMap(ParameterMap &param, ::detail::json &o) {
 }
 #endif
 
-static void SerializeExtensionMap(const ExtensionMap &extensions, ::detail::json &o) {
+static void SerializeExtensionMap(const ExtensionMap &extensions, detail::json &o) {
   if (!extensions.size()) return;
 
-  ::detail::json extMap;
+  detail::json extMap;
   for (ExtensionMap::const_iterator extIt = extensions.begin();
        extIt != extensions.end(); ++extIt) {
     // Allow an empty object for extension(#97)
-    ::detail::json ret;
+    detail::json ret;
     bool isNull = true;
     if (ValueToJson(extIt->second, &ret)) {
       isNull = detail::JsonIsNull(ret);
@@ -6858,7 +6860,7 @@ static void SerializeExtensionMap(const ExtensionMap &extensions, ::detail::json
       if (!(extIt->first.empty())) {  // name should not be empty, but for sure
         // create empty object so that an extension name is still included in
         // json.
-        ::detail::json empty;
+        detail::json empty;
         detail::JsonSetObject(empty);
         detail::JsonAddMember(extMap, extIt->first.c_str(), std::move(empty));
       }
@@ -6867,7 +6869,7 @@ static void SerializeExtensionMap(const ExtensionMap &extensions, ::detail::json
   detail::JsonAddMember(o, "extensions", std::move(extMap));
 }
 
-static void SerializeGltfAccessor(const Accessor &accessor, ::detail::json &o) {
+static void SerializeGltfAccessor(const Accessor &accessor, detail::json &o) {
   if (accessor.bufferView >= 0)
     SerializeNumberProperty<int>("bufferView", accessor.bufferView, o);
 
@@ -6940,17 +6942,17 @@ static void SerializeGltfAccessor(const Accessor &accessor, ::detail::json &o) {
   // sparse
   if (accessor.sparse.isSparse)
   {
-      ::detail::json sparse;
+      detail::json sparse;
       SerializeNumberProperty<int>("count", accessor.sparse.count, sparse);
       {
-          ::detail::json indices;
+          detail::json indices;
           SerializeNumberProperty<int>("bufferView", accessor.sparse.indices.bufferView, indices);
           SerializeNumberProperty<int>("byteOffset", accessor.sparse.indices.byteOffset, indices);
           SerializeNumberProperty<int>("componentType", accessor.sparse.indices.componentType, indices);
           detail::JsonAddMember(sparse, "indices", std::move(indices));
       }
       {
-          ::detail::json values;
+          detail::json values;
           SerializeNumberProperty<int>("bufferView", accessor.sparse.values.bufferView, values);
           SerializeNumberProperty<int>("byteOffset", accessor.sparse.values.byteOffset, values);
           detail::JsonAddMember(sparse, "values", std::move(values));
@@ -6960,10 +6962,10 @@ static void SerializeGltfAccessor(const Accessor &accessor, ::detail::json &o) {
 }
 
 static void SerializeGltfAnimationChannel(const AnimationChannel &channel,
-                                          ::detail::json &o) {
+                                          detail::json &o) {
   SerializeNumberProperty("sampler", channel.sampler, o);
   {
-    ::detail::json target;
+    detail::json target;
 
     if (channel.target_node > 0) {
       SerializeNumberProperty("node", channel.target_node, target);
@@ -6984,7 +6986,7 @@ static void SerializeGltfAnimationChannel(const AnimationChannel &channel,
 }
 
 static void SerializeGltfAnimationSampler(const AnimationSampler &sampler,
-                                          ::detail::json &o) {
+                                          detail::json &o) {
   SerializeNumberProperty("input", sampler.input, o);
   SerializeNumberProperty("output", sampler.output, o);
   SerializeStringProperty("interpolation", sampler.interpolation, o);
@@ -6994,15 +6996,15 @@ static void SerializeGltfAnimationSampler(const AnimationSampler &sampler,
   }
 }
 
-static void SerializeGltfAnimation(const Animation &animation, ::detail::json &o) {
+static void SerializeGltfAnimation(const Animation &animation, detail::json &o) {
   if (!animation.name.empty())
     SerializeStringProperty("name", animation.name, o);
 
   {
-    ::detail::json channels;
+    detail::json channels;
     detail::JsonReserveArray(channels, animation.channels.size());
     for (unsigned int i = 0; i < animation.channels.size(); ++i) {
-      ::detail::json channel;
+      detail::json channel;
       AnimationChannel gltfChannel = animation.channels[i];
       SerializeGltfAnimationChannel(gltfChannel, channel);
       detail::JsonPushBack(channels, std::move(channel));
@@ -7012,10 +7014,10 @@ static void SerializeGltfAnimation(const Animation &animation, ::detail::json &o
   }
 
   {
-    ::detail::json samplers;
+    detail::json samplers;
     detail::JsonReserveArray(samplers, animation.samplers.size());
     for (unsigned int i = 0; i < animation.samplers.size(); ++i) {
-      ::detail::json sampler;
+      detail::json sampler;
       AnimationSampler gltfSampler = animation.samplers[i];
       SerializeGltfAnimationSampler(gltfSampler, sampler);
       detail::JsonPushBack(samplers, std::move(sampler));
@@ -7030,7 +7032,7 @@ static void SerializeGltfAnimation(const Animation &animation, ::detail::json &o
   SerializeExtensionMap(animation.extensions, o);
 }
 
-static void SerializeGltfAsset(const Asset &asset, ::detail::json &o) {
+static void SerializeGltfAsset(const Asset &asset, detail::json &o) {
   if (!asset.generator.empty()) {
     SerializeStringProperty("generator", asset.generator, o);
   }
@@ -7056,7 +7058,7 @@ static void SerializeGltfAsset(const Asset &asset, ::detail::json &o) {
   SerializeExtensionMap(asset.extensions, o);
 }
 
-static void SerializeGltfBufferBin(const Buffer &buffer, ::detail::json &o,
+static void SerializeGltfBufferBin(const Buffer &buffer, detail::json &o,
                                    std::vector<unsigned char> &binBuffer) {
   SerializeNumberProperty("byteLength", buffer.data.size(), o);
   binBuffer = buffer.data;
@@ -7068,7 +7070,7 @@ static void SerializeGltfBufferBin(const Buffer &buffer, ::detail::json &o,
   }
 }
 
-static void SerializeGltfBuffer(const Buffer &buffer, ::detail::json &o) {
+static void SerializeGltfBuffer(const Buffer &buffer, detail::json &o) {
   SerializeNumberProperty("byteLength", buffer.data.size(), o);
   SerializeGltfBufferData(buffer.data, o);
 
@@ -7079,7 +7081,7 @@ static void SerializeGltfBuffer(const Buffer &buffer, ::detail::json &o) {
   }
 }
 
-static bool SerializeGltfBuffer(const Buffer &buffer, ::detail::json &o,
+static bool SerializeGltfBuffer(const Buffer &buffer, detail::json &o,
                                 const std::string &binFilename,
                                 const std::string &binUri) {
   if (!SerializeGltfBufferData(buffer.data, binFilename)) return false;
@@ -7094,7 +7096,7 @@ static bool SerializeGltfBuffer(const Buffer &buffer, ::detail::json &o,
   return true;
 }
 
-static void SerializeGltfBufferView(const BufferView &bufferView, ::detail::json &o) {
+static void SerializeGltfBufferView(const BufferView &bufferView, detail::json &o) {
   SerializeNumberProperty("buffer", bufferView.buffer, o);
   SerializeNumberProperty<size_t>("byteLength", bufferView.byteLength, o);
 
@@ -7121,7 +7123,7 @@ static void SerializeGltfBufferView(const BufferView &bufferView, ::detail::json
 }
 
 static void SerializeGltfImage(const Image &image, const std::string &uri,
-                               ::detail::json &o) {
+                               detail::json &o) {
   // From 2.7.0, we look for `uri` parameter, not `Image.uri`
   // if uri is empty, the mimeType and bufferview should be set
   if (uri.empty()) {
@@ -7142,7 +7144,7 @@ static void SerializeGltfImage(const Image &image, const std::string &uri,
   SerializeExtensionMap(image.extensions, o);
 }
 
-static void SerializeGltfTextureInfo(const TextureInfo &texinfo, ::detail::json &o) {
+static void SerializeGltfTextureInfo(const TextureInfo &texinfo, detail::json &o) {
   SerializeNumberProperty("index", texinfo.index, o);
 
   if (texinfo.texCoord != 0) {
@@ -7157,7 +7159,7 @@ static void SerializeGltfTextureInfo(const TextureInfo &texinfo, ::detail::json 
 }
 
 static void SerializeGltfNormalTextureInfo(const NormalTextureInfo &texinfo,
-                                           ::detail::json &o) {
+                                           detail::json &o) {
   SerializeNumberProperty("index", texinfo.index, o);
 
   if (texinfo.texCoord != 0) {
@@ -7176,7 +7178,7 @@ static void SerializeGltfNormalTextureInfo(const NormalTextureInfo &texinfo,
 }
 
 static void SerializeGltfOcclusionTextureInfo(
-    const OcclusionTextureInfo &texinfo, ::detail::json &o) {
+    const OcclusionTextureInfo &texinfo, detail::json &o) {
   SerializeNumberProperty("index", texinfo.index, o);
 
   if (texinfo.texCoord != 0) {
@@ -7195,7 +7197,7 @@ static void SerializeGltfOcclusionTextureInfo(
 }
 
 static void SerializeGltfPbrMetallicRoughness(const PbrMetallicRoughness &pbr,
-                                              ::detail::json &o) {
+                                              detail::json &o) {
   std::vector<double> default_baseColorFactor = {1.0, 1.0, 1.0, 1.0};
   if (!Equals(pbr.baseColorFactor, default_baseColorFactor)) {
     SerializeNumberArrayProperty<double>("baseColorFactor", pbr.baseColorFactor,
@@ -7211,13 +7213,13 @@ static void SerializeGltfPbrMetallicRoughness(const PbrMetallicRoughness &pbr,
   }
 
   if (pbr.baseColorTexture.index > -1) {
-    ::detail::json texinfo;
+    detail::json texinfo;
     SerializeGltfTextureInfo(pbr.baseColorTexture, texinfo);
     detail::JsonAddMember(o, "baseColorTexture", std::move(texinfo));
   }
 
   if (pbr.metallicRoughnessTexture.index > -1) {
-    ::detail::json texinfo;
+    detail::json texinfo;
     SerializeGltfTextureInfo(pbr.metallicRoughnessTexture, texinfo);
     detail::JsonAddMember(o, "metallicRoughnessTexture", std::move(texinfo));
   }
@@ -7229,7 +7231,7 @@ static void SerializeGltfPbrMetallicRoughness(const PbrMetallicRoughness &pbr,
   }
 }
 
-static void SerializeGltfMaterial(const Material &material, ::detail::json &o) {
+static void SerializeGltfMaterial(const Material &material, detail::json &o) {
   if (material.name.size()) {
     SerializeStringProperty("name", material.name, o);
   }
@@ -7245,22 +7247,22 @@ static void SerializeGltfMaterial(const Material &material, ::detail::json &o) {
   }
 
   if (material.doubleSided != false)
-    detail::JsonAddMember(o, "doubleSided", ::detail::json(material.doubleSided));
+    detail::JsonAddMember(o, "doubleSided", detail::json(material.doubleSided));
 
   if (material.normalTexture.index > -1) {
-    ::detail::json texinfo;
+    detail::json texinfo;
     SerializeGltfNormalTextureInfo(material.normalTexture, texinfo);
     detail::JsonAddMember(o, "normalTexture", std::move(texinfo));
   }
 
   if (material.occlusionTexture.index > -1) {
-    ::detail::json texinfo;
+    detail::json texinfo;
     SerializeGltfOcclusionTextureInfo(material.occlusionTexture, texinfo);
     detail::JsonAddMember(o, "occlusionTexture", std::move(texinfo));
   }
 
   if (material.emissiveTexture.index > -1) {
-    ::detail::json texinfo;
+    detail::json texinfo;
     SerializeGltfTextureInfo(material.emissiveTexture, texinfo);
     detail::JsonAddMember(o, "emissiveTexture", std::move(texinfo));
   }
@@ -7272,7 +7274,7 @@ static void SerializeGltfMaterial(const Material &material, ::detail::json &o) {
   }
 
   {
-    ::detail::json pbrMetallicRoughness;
+    detail::json pbrMetallicRoughness;
     SerializeGltfPbrMetallicRoughness(material.pbrMetallicRoughness,
                                       pbrMetallicRoughness);
     // Issue 204
@@ -7288,7 +7290,7 @@ static void SerializeGltfMaterial(const Material &material, ::detail::json &o) {
 
 #if 0  // legacy way. just for the record.
   if (material.values.size()) {
-    ::detail::json pbrMetallicRoughness;
+    detail::json pbrMetallicRoughness;
     SerializeParameterMap(material.values, pbrMetallicRoughness);
     detail::JsonAddMember(o, "pbrMetallicRoughness", std::move(pbrMetallicRoughness));
   }
@@ -7305,14 +7307,14 @@ static void SerializeGltfMaterial(const Material &material, ::detail::json &o) {
   }
 }
 
-static void SerializeGltfMesh(const Mesh &mesh, ::detail::json &o) {
-  ::detail::json primitives;
+static void SerializeGltfMesh(const Mesh &mesh, detail::json &o) {
+  detail::json primitives;
   detail::JsonReserveArray(primitives, mesh.primitives.size());
   for (unsigned int i = 0; i < mesh.primitives.size(); ++i) {
-    ::detail::json primitive;
+    detail::json primitive;
     const Primitive &gltfPrimitive = mesh.primitives[i];  // don't make a copy
     {
-      ::detail::json attributes;
+      detail::json attributes;
       for (auto attrIt = gltfPrimitive.attributes.begin();
            attrIt != gltfPrimitive.attributes.end(); ++attrIt) {
         SerializeNumberProperty<int>(attrIt->first, attrIt->second, attributes);
@@ -7334,10 +7336,10 @@ static void SerializeGltfMesh(const Mesh &mesh, ::detail::json &o) {
 
     // Morph targets
     if (gltfPrimitive.targets.size()) {
-      ::detail::json targets;
+      detail::json targets;
       detail::JsonReserveArray(targets, gltfPrimitive.targets.size());
       for (unsigned int k = 0; k < gltfPrimitive.targets.size(); ++k) {
-        ::detail::json targetAttributes;
+        detail::json targetAttributes;
         std::map<std::string, int> targetData = gltfPrimitive.targets[k];
         for (std::map<std::string, int>::iterator attrIt = targetData.begin();
              attrIt != targetData.end(); ++attrIt) {
@@ -7374,7 +7376,7 @@ static void SerializeGltfMesh(const Mesh &mesh, ::detail::json &o) {
   }
 }
 
-static void SerializeSpotLight(const SpotLight &spot, ::detail::json &o) {
+static void SerializeSpotLight(const SpotLight &spot, detail::json &o) {
   SerializeNumberProperty("innerConeAngle", spot.innerConeAngle, o);
   SerializeNumberProperty("outerConeAngle", spot.outerConeAngle, o);
   SerializeExtensionMap(spot.extensions, o);
@@ -7383,7 +7385,7 @@ static void SerializeSpotLight(const SpotLight &spot, ::detail::json &o) {
   }
 }
 
-static void SerializeGltfLight(const Light &light, ::detail::json &o) {
+static void SerializeGltfLight(const Light &light, detail::json &o) {
   if (!light.name.empty()) SerializeStringProperty("name", light.name, o);
   SerializeNumberProperty("intensity", light.intensity, o);
   if (light.range > 0.0) {
@@ -7392,7 +7394,7 @@ static void SerializeGltfLight(const Light &light, ::detail::json &o) {
   SerializeNumberArrayProperty("color", light.color, o);
   SerializeStringProperty("type", light.type, o);
   if (light.type == "spot") {
-    ::detail::json spot;
+    detail::json spot;
     SerializeSpotLight(light.spot, spot);
     detail::JsonAddMember(o, "spot", std::move(spot));
   }
@@ -7402,7 +7404,7 @@ static void SerializeGltfLight(const Light &light, ::detail::json &o) {
   }
 }
 
-static void SerializeGltfNode(const Node &node, ::detail::json &o) {
+static void SerializeGltfNode(const Node &node, detail::json &o) {
   if (node.translation.size() > 0) {
     SerializeNumberArrayProperty<double>("translation", node.translation, o);
   }
@@ -7440,7 +7442,7 @@ static void SerializeGltfNode(const Node &node, ::detail::json &o) {
   SerializeNumberArrayProperty<int>("children", node.children, o);
 }
 
-static void SerializeGltfSampler(const Sampler &sampler, ::detail::json &o) {
+static void SerializeGltfSampler(const Sampler &sampler, detail::json &o) {
   if (!sampler.name.empty()) {
     SerializeStringProperty("name", sampler.name, o);
   }
@@ -7460,7 +7462,7 @@ static void SerializeGltfSampler(const Sampler &sampler, ::detail::json &o) {
 }
 
 static void SerializeGltfOrthographicCamera(const OrthographicCamera &camera,
-                                            ::detail::json &o) {
+                                            detail::json &o) {
   SerializeNumberProperty("zfar", camera.zfar, o);
   SerializeNumberProperty("znear", camera.znear, o);
   SerializeNumberProperty("xmag", camera.xmag, o);
@@ -7472,7 +7474,7 @@ static void SerializeGltfOrthographicCamera(const OrthographicCamera &camera,
 }
 
 static void SerializeGltfPerspectiveCamera(const PerspectiveCamera &camera,
-                                           ::detail::json &o) {
+                                           detail::json &o) {
   SerializeNumberProperty("zfar", camera.zfar, o);
   SerializeNumberProperty("znear", camera.znear, o);
   if (camera.aspectRatio > 0) {
@@ -7488,18 +7490,18 @@ static void SerializeGltfPerspectiveCamera(const PerspectiveCamera &camera,
   }
 }
 
-static void SerializeGltfCamera(const Camera &camera, ::detail::json &o) {
+static void SerializeGltfCamera(const Camera &camera, detail::json &o) {
   SerializeStringProperty("type", camera.type, o);
   if (!camera.name.empty()) {
     SerializeStringProperty("name", camera.name, o);
   }
 
   if (camera.type.compare("orthographic") == 0) {
-    ::detail::json orthographic;
+    detail::json orthographic;
     SerializeGltfOrthographicCamera(camera.orthographic, orthographic);
     detail::JsonAddMember(o, "orthographic", std::move(orthographic));
   } else if (camera.type.compare("perspective") == 0) {
-    ::detail::json perspective;
+    detail::json perspective;
     SerializeGltfPerspectiveCamera(camera.perspective, perspective);
     detail::JsonAddMember(o, "perspective", std::move(perspective));
   } else {
@@ -7512,7 +7514,7 @@ static void SerializeGltfCamera(const Camera &camera, ::detail::json &o) {
   SerializeExtensionMap(camera.extensions, o);
 }
 
-static void SerializeGltfScene(const Scene &scene, ::detail::json &o) {
+static void SerializeGltfScene(const Scene &scene, detail::json &o) {
   SerializeNumberArrayProperty<int>("nodes", scene.nodes, o);
 
   if (scene.name.size()) {
@@ -7524,7 +7526,7 @@ static void SerializeGltfScene(const Scene &scene, ::detail::json &o) {
   SerializeExtensionMap(scene.extensions, o);
 }
 
-static void SerializeGltfSkin(const Skin &skin, ::detail::json &o) {
+static void SerializeGltfSkin(const Skin &skin, detail::json &o) {
   // required
   SerializeNumberArrayProperty<int>("joints", skin.joints, o);
 
@@ -7541,7 +7543,7 @@ static void SerializeGltfSkin(const Skin &skin, ::detail::json &o) {
   }
 }
 
-static void SerializeGltfTexture(const Texture &texture, ::detail::json &o) {
+static void SerializeGltfTexture(const Texture &texture, detail::json &o) {
   if (texture.sampler > -1) {
     SerializeNumberProperty("sampler", texture.sampler, o);
   }
@@ -7560,13 +7562,13 @@ static void SerializeGltfTexture(const Texture &texture, ::detail::json &o) {
 ///
 /// Serialize all properties except buffers and images.
 ///
-static void SerializeGltfModel(const Model *model, ::detail::json &o) {
+static void SerializeGltfModel(const Model *model, detail::json &o) {
   // ACCESSORS
   if (model->accessors.size()) {
-    ::detail::json accessors;
+    detail::json accessors;
     detail::JsonReserveArray(accessors, model->accessors.size());
     for (unsigned int i = 0; i < model->accessors.size(); ++i) {
-      ::detail::json accessor;
+      detail::json accessor;
       SerializeGltfAccessor(model->accessors[i], accessor);
       detail::JsonPushBack(accessors, std::move(accessor));
     }
@@ -7575,11 +7577,11 @@ static void SerializeGltfModel(const Model *model, ::detail::json &o) {
 
   // ANIMATIONS
   if (model->animations.size()) {
-    ::detail::json animations;
+    detail::json animations;
     detail::JsonReserveArray(animations, model->animations.size());
     for (unsigned int i = 0; i < model->animations.size(); ++i) {
       if (model->animations[i].channels.size()) {
-        ::detail::json animation;
+        detail::json animation;
         SerializeGltfAnimation(model->animations[i], animation);
         detail::JsonPushBack(animations, std::move(animation));
       }
@@ -7589,16 +7591,16 @@ static void SerializeGltfModel(const Model *model, ::detail::json &o) {
   }
 
   // ASSET
-  ::detail::json asset;
+  detail::json asset;
   SerializeGltfAsset(model->asset, asset);
   detail::JsonAddMember(o, "asset", std::move(asset));
 
   // BUFFERVIEWS
   if (model->bufferViews.size()) {
-    ::detail::json bufferViews;
+    detail::json bufferViews;
     detail::JsonReserveArray(bufferViews, model->bufferViews.size());
     for (unsigned int i = 0; i < model->bufferViews.size(); ++i) {
-      ::detail::json bufferView;
+      detail::json bufferView;
       SerializeGltfBufferView(model->bufferViews[i], bufferView);
       detail::JsonPushBack(bufferViews, std::move(bufferView));
     }
@@ -7613,10 +7615,10 @@ static void SerializeGltfModel(const Model *model, ::detail::json &o) {
 
   // MATERIALS
   if (model->materials.size()) {
-    ::detail::json materials;
+    detail::json materials;
     detail::JsonReserveArray(materials, model->materials.size());
     for (unsigned int i = 0; i < model->materials.size(); ++i) {
-      ::detail::json material;
+      detail::json material;
       SerializeGltfMaterial(model->materials[i], material);
 
       if (detail::JsonIsNull(material)) {
@@ -7635,10 +7637,10 @@ static void SerializeGltfModel(const Model *model, ::detail::json &o) {
 
   // MESHES
   if (model->meshes.size()) {
-    ::detail::json meshes;
+    detail::json meshes;
     detail::JsonReserveArray(meshes, model->meshes.size());
     for (unsigned int i = 0; i < model->meshes.size(); ++i) {
-      ::detail::json mesh;
+      detail::json mesh;
       SerializeGltfMesh(model->meshes[i], mesh);
       detail::JsonPushBack(meshes, std::move(mesh));
     }
@@ -7647,10 +7649,10 @@ static void SerializeGltfModel(const Model *model, ::detail::json &o) {
 
   // NODES
   if (model->nodes.size()) {
-    ::detail::json nodes;
+    detail::json nodes;
     detail::JsonReserveArray(nodes, model->nodes.size());
     for (unsigned int i = 0; i < model->nodes.size(); ++i) {
-      ::detail::json node;
+      detail::json node;
       SerializeGltfNode(model->nodes[i], node);
       detail::JsonPushBack(nodes, std::move(node));
     }
@@ -7664,10 +7666,10 @@ static void SerializeGltfModel(const Model *model, ::detail::json &o) {
 
   // SCENES
   if (model->scenes.size()) {
-    ::detail::json scenes;
+    detail::json scenes;
     detail::JsonReserveArray(scenes, model->scenes.size());
     for (unsigned int i = 0; i < model->scenes.size(); ++i) {
-      ::detail::json currentScene;
+      detail::json currentScene;
       SerializeGltfScene(model->scenes[i], currentScene);
       detail::JsonPushBack(scenes, std::move(currentScene));
     }
@@ -7676,10 +7678,10 @@ static void SerializeGltfModel(const Model *model, ::detail::json &o) {
 
   // SKINS
   if (model->skins.size()) {
-    ::detail::json skins;
+    detail::json skins;
     detail::JsonReserveArray(skins, model->skins.size());
     for (unsigned int i = 0; i < model->skins.size(); ++i) {
-      ::detail::json skin;
+      detail::json skin;
       SerializeGltfSkin(model->skins[i], skin);
       detail::JsonPushBack(skins, std::move(skin));
     }
@@ -7688,10 +7690,10 @@ static void SerializeGltfModel(const Model *model, ::detail::json &o) {
 
   // TEXTURES
   if (model->textures.size()) {
-    ::detail::json textures;
+    detail::json textures;
     detail::JsonReserveArray(textures, model->textures.size());
     for (unsigned int i = 0; i < model->textures.size(); ++i) {
-      ::detail::json texture;
+      detail::json texture;
       SerializeGltfTexture(model->textures[i], texture);
       detail::JsonPushBack(textures, std::move(texture));
     }
@@ -7700,10 +7702,10 @@ static void SerializeGltfModel(const Model *model, ::detail::json &o) {
 
   // SAMPLERS
   if (model->samplers.size()) {
-    ::detail::json samplers;
+    detail::json samplers;
     detail::JsonReserveArray(samplers, model->samplers.size());
     for (unsigned int i = 0; i < model->samplers.size(); ++i) {
-      ::detail::json sampler;
+      detail::json sampler;
       SerializeGltfSampler(model->samplers[i], sampler);
       detail::JsonPushBack(samplers, std::move(sampler));
     }
@@ -7712,10 +7714,10 @@ static void SerializeGltfModel(const Model *model, ::detail::json &o) {
 
   // CAMERAS
   if (model->cameras.size()) {
-    ::detail::json cameras;
+    detail::json cameras;
     detail::JsonReserveArray(cameras, model->cameras.size());
     for (unsigned int i = 0; i < model->cameras.size(); ++i) {
-      ::detail::json camera;
+      detail::json camera;
       SerializeGltfCamera(model->cameras[i], camera);
       detail::JsonPushBack(cameras, std::move(camera));
     }
@@ -7729,19 +7731,19 @@ static void SerializeGltfModel(const Model *model, ::detail::json &o) {
 
   // LIGHTS as KHR_lights_punctual
   if (model->lights.size()) {
-    ::detail::json lights;
+    detail::json lights;
     detail::JsonReserveArray(lights, model->lights.size());
     for (unsigned int i = 0; i < model->lights.size(); ++i) {
-      ::detail::json light;
+      detail::json light;
       SerializeGltfLight(model->lights[i], light);
       detail::JsonPushBack(lights, std::move(light));
     }
-    ::detail::json khr_lights_cmn;
+    detail::json khr_lights_cmn;
     detail::JsonAddMember(khr_lights_cmn, "lights", std::move(lights));
-    ::detail::json ext_j;
+    detail::json ext_j;
 
     {
-      ::detail::json_const_iterator it;
+      detail::json_const_iterator it;
       if (detail::FindMember(o, "extensions", it)) {
         detail::JsonAssign(ext_j, detail::GetValue(it));
       }
@@ -7889,7 +7891,7 @@ static bool WriteBinaryGltfFile(const std::string &output,
 bool TinyGLTF::WriteGltfSceneToStream(const Model *model, std::ostream &stream,
                                       bool prettyPrint = true,
                                       bool writeBinary = false) {
-  ::detail::JsonDocument output;
+  detail::JsonDocument output;
 
   /// Serialize all properties except buffers and images.
   SerializeGltfModel(model, output);
@@ -7897,10 +7899,10 @@ bool TinyGLTF::WriteGltfSceneToStream(const Model *model, std::ostream &stream,
   // BUFFERS
   std::vector<unsigned char> binBuffer;
   if (model->buffers.size()) {
-    ::detail::json buffers;
+    detail::json buffers;
     detail::JsonReserveArray(buffers, model->buffers.size());
     for (unsigned int i = 0; i < model->buffers.size(); ++i) {
-      ::detail::json buffer;
+      detail::json buffer;
       if (writeBinary && i == 0 && model->buffers[i].uri.empty()) {
         SerializeGltfBufferBin(model->buffers[i], buffer, binBuffer);
       } else {
@@ -7913,10 +7915,10 @@ bool TinyGLTF::WriteGltfSceneToStream(const Model *model, std::ostream &stream,
 
   // IMAGES
   if (model->images.size()) {
-    ::detail::json images;
+    detail::json images;
     detail::JsonReserveArray(images, model->images.size());
     for (unsigned int i = 0; i < model->images.size(); ++i) {
-      ::detail::json image;
+      detail::json image;
 
       std::string dummystring = "";
       // UpdateImageObject need baseDir but only uses it if embeddedImages is
@@ -7947,7 +7949,7 @@ bool TinyGLTF::WriteGltfSceneToFile(const Model *model,
                                     bool embedBuffers = false,
                                     bool prettyPrint = true,
                                     bool writeBinary = false) {
-  ::detail::JsonDocument output;
+  detail::JsonDocument output;
   std::string defaultBinFilename = GetBaseFilename(filename);
   std::string defaultBinFileExt = ".bin";
   std::string::size_type pos =
@@ -7967,10 +7969,10 @@ bool TinyGLTF::WriteGltfSceneToFile(const Model *model,
   std::vector<std::string> usedFilenames;
   std::vector<unsigned char> binBuffer;
   if (model->buffers.size()) {
-    ::detail::json buffers;
+    detail::json buffers;
     detail::JsonReserveArray(buffers, model->buffers.size());
     for (unsigned int i = 0; i < model->buffers.size(); ++i) {
-      ::detail::json buffer;
+      detail::json buffer;
       if (writeBinary && i == 0 && model->buffers[i].uri.empty()) {
         SerializeGltfBufferBin(model->buffers[i], buffer, binBuffer);
       } else if (embedBuffers) {
@@ -8023,10 +8025,10 @@ bool TinyGLTF::WriteGltfSceneToFile(const Model *model,
 
   // IMAGES
   if (model->images.size()) {
-    ::detail::json images;
+    detail::json images;
     detail::JsonReserveArray(images, model->images.size());
     for (unsigned int i = 0; i < model->images.size(); ++i) {
-      ::detail::json image;
+      detail::json image;
 
       std::string uri;
       if (!UpdateImageObject(model->images[i], baseDir, int(i), embedImages,


### PR DESCRIPTION
Fixes issue #406 

Ran parser & unit tests, and it all passed.

Don't even need to rename `json` in this case. For some weird reason it has to use `::detail::json` instead of `detail::json`. I have no idea why.

