### PR TITLE
Added error checking to ostream writing

### DIFF
--- a/tests/tester.cc
+++ b/tests/tester.cc
@@ -504,7 +504,8 @@ TEST_CASE("serialize-empty-material", "[issue-294]") {
   std::stringstream os;
 
   tinygltf::TinyGLTF ctx;
-  ctx.WriteGltfSceneToStream(&m, os, false, false);
+  bool ret = ctx.WriteGltfSceneToStream(&m, os, false, false);
+  REQUIRE(true == ret);
 
   // use nlohmann json
   nlohmann::json j = nlohmann::json::parse(os.str());
@@ -532,7 +533,8 @@ TEST_CASE("empty-skeleton-id", "[issue-321]") {
 
   std::stringstream os;
 
-  ctx.WriteGltfSceneToStream(&model, os, false, false);
+  ret = ctx.WriteGltfSceneToStream(&model, os, false, false);
+  REQUIRE(true == ret);
 
   // use nlohmann json
   nlohmann::json j = nlohmann::json::parse(os.str());
@@ -634,8 +636,9 @@ TEST_CASE("serialize-const-image", "[issue-394]") {
   std::stringstream os;
 
   tinygltf::TinyGLTF ctx;
-  ctx.WriteGltfSceneToStream(const_cast<const tinygltf::Model *>(&m), os, false,
+  bool ret = ctx.WriteGltfSceneToStream(const_cast<const tinygltf::Model *>(&m), os, false,
                              false);
+  REQUIRE(true == ret);
   REQUIRE(m.images[0].uri == i.uri);
 
   // use nlohmann json

--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -7780,7 +7780,7 @@ static void SerializeGltfModel(const Model *model, detail::json &o) {
 
 static bool WriteGltfStream(std::ostream &stream, const std::string &content) {
   stream << content << std::endl;
-  return true;
+  return stream.good();
 }
 
 static bool WriteGltfFile(const std::string &output,
@@ -7863,8 +7863,8 @@ static bool WriteBinaryGltfStream(std::ostream &stream,
     }
   }
 
-  // TODO: Check error on stream.write
-  return true;
+  stream.flush();
+  return stream.good();
 }
 
 static bool WriteBinaryGltfFile(const std::string &output,


### PR DESCRIPTION
This PR implements error checking on the output stream after all writing has been done and returns the state of the stream to the caller (related issue: #365).