### PR TITLE
Fix serialization of AnimationChannel::target_node when it is zero

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -6970,7 +6970,7 @@ static void SerializeGltfAnimationChannel(const AnimationChannel &channel,
   {
     detail::json target;
 
-    if (channel.target_node > 0) {
+    if (channel.target_node >= 0) {
       SerializeNumberProperty("node", channel.target_node, target);
     }
 


### PR DESCRIPTION
Fix serialization of AnimationChannel::target_node when it is zero.