### PR TITLE
Modernize

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,14 @@
 cmake_minimum_required(VERSION 3.6)
 
-PROJECT (tinygltf)
+project(tinygltf)
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
-SET(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED On)
+set(CMAKE_CXX_EXTENSIONS Off)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 option(TINYGLTF_BUILD_LOADER_EXAMPLE "Build loader_example(load glTF and dump infos)" ON)
 option(TINYGLTF_BUILD_GL_EXAMPLES "Build GL exampels(requires glfw, OpenGL, etc)" OFF)
@@ -15,22 +18,22 @@ option(TINYGLTF_HEADER_ONLY "On: header-only mode. Off: create tinygltf library(
 option(TINYGLTF_INSTALL "Install tinygltf files during install step. Usually set to OFF if you include tinygltf through add_subdirectory()" ON)
 
 if (TINYGLTF_BUILD_LOADER_EXAMPLE)
-  ADD_EXECUTABLE ( loader_example
+  add_executable(loader_example
     loader_example.cc
     )
 endif (TINYGLTF_BUILD_LOADER_EXAMPLE)
 
 if (TINYGLTF_BUILD_GL_EXAMPLES)
-  ADD_SUBDIRECTORY ( examples/gltfutil )
-  ADD_SUBDIRECTORY ( examples/glview )
+  add_subdirectory( examples/gltfutil )
+  add_subdirectory( examples/glview )
 endif (TINYGLTF_BUILD_GL_EXAMPLES)
 
 if (TINYGLTF_BUILD_VALIDATOR_EXAMPLE)
-  ADD_SUBDIRECTORY ( examples/validator )
+  add_subdirectory( examples/validator )
 endif (TINYGLTF_BUILD_VALIDATOR_EXAMPLE)
 
 if (TINYGLTF_BUILD_BUILDER_EXAMPLE)
-  ADD_SUBDIRECTORY ( examples/build-gltf )
+  add_subdirectory ( examples/build-gltf )
 endif (TINYGLTF_BUILD_BUILDER_EXAMPLE)
 
 #

--- a/examples/build-gltf/CMakeLists.txt
+++ b/examples/build-gltf/CMakeLists.txt
@@ -1,0 +1,5 @@
+
+include_directories(${CMAKE_SOURCE_DIR})
+add_executable(create_triangle_gltf create_triangle_gltf.cpp)
+target_compile_options(create_triangle_gltf PUBLIC -Wall)
+target_link_libraries(create_triangle_gltf )

--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -8185,7 +8185,7 @@ bool TinyGLTF::WriteGltfSceneToStream(const Model *model, std::ostream &stream,
     for (unsigned int i = 0; i < model->images.size(); ++i) {
       detail::json image;
 
-      std::string dummystring = "";
+      std::string dummystring;
       // UpdateImageObject need baseDir but only uses it if embeddedImages is
       // enabled, since we won't write separate images when writing to a stream
       // we

--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -572,9 +572,9 @@ struct Animation {
 
 struct Skin {
   std::string name;
-  int inverseBindMatrices;  // required here but not in the spec
-  int skeleton;             // The index of the node used as a skeleton root
-  std::vector<int> joints;  // Indices of skeleton nodes
+  int inverseBindMatrices{-1};  // required here but not in the spec
+  int skeleton{-1};             // The index of the node used as a skeleton root
+  std::vector<int> joints;      // Indices of skeleton nodes
 
   Value extras;
   ExtensionMap extensions;
@@ -583,10 +583,7 @@ struct Skin {
   std::string extras_json_string;
   std::string extensions_json_string;
 
-  Skin() {
-    inverseBindMatrices = -1;
-    skeleton = -1;
-  }
+  Skin() = default;
   DEFAULT_METHODS(Skin)
   bool operator==(const Skin &) const;
 };
@@ -624,14 +621,14 @@ struct Sampler {
 
 struct Image {
   std::string name;
-  int width;
-  int height;
-  int component;
-  int bits;        // bit depth per channel. 8(byte), 16 or 32.
-  int pixel_type;  // pixel type(TINYGLTF_COMPONENT_TYPE_***). usually
-                   // UBYTE(bits = 8) or USHORT(bits = 16)
+  int width{-1};
+  int height{-1};
+  int component{-1};
+  int bits{-1};        // bit depth per channel. 8(byte), 16 or 32.
+  int pixel_type{-1};  // pixel type(TINYGLTF_COMPONENT_TYPE_***). usually
+                       // UBYTE(bits = 8) or USHORT(bits = 16)
   std::vector<unsigned char> image;
-  int bufferView;        // (required if no uri)
+  int bufferView{-1};    // (required if no uri)
   std::string mimeType;  // (required if no uri) ["image/jpeg", "image/png",
                          // "image/bmp", "image/gif"]
   std::string uri;       // (required if no mimeType) uri is not decoded(e.g.
@@ -651,14 +648,7 @@ struct Image {
   // function)
   bool as_is{false};
 
-  Image() {
-    bufferView = -1;
-    width = -1;
-    height = -1;
-    component = -1;
-    bits = -1;
-    pixel_type = -1;
-  }
+  Image() = default;
   DEFAULT_METHODS(Image)
 
   bool operator==(const Image &) const;
@@ -972,10 +962,10 @@ struct Primitive {
                                           // integer, where each integer
                                           // is the index of the accessor
                                           // containing an attribute.
-  int material;  // The index of the material to apply to this primitive
-                 // when rendering.
-  int indices;   // The index of the accessor that contains the indices.
-  int mode;      // one of TINYGLTF_MODE_***
+  int material{-1};  // The index of the material to apply to this primitive
+                     // when rendering.
+  int indices{-1};   // The index of the accessor that contains the indices.
+  int mode{-1};      // one of TINYGLTF_MODE_***
   std::vector<std::map<std::string, int> > targets;  // array of morph targets,
   // where each target is a dict with attributes in ["POSITION, "NORMAL",
   // "TANGENT"] pointing
@@ -987,11 +977,7 @@ struct Primitive {
   std::string extras_json_string;
   std::string extensions_json_string;
 
-  Primitive() {
-    material = -1;
-    indices = -1;
-    mode = -1;
-  }
+  Primitive() = default;
   DEFAULT_METHODS(Primitive)
   bool operator==(const Primitive &) const;
 };
@@ -1238,7 +1224,7 @@ class Model {
   std::vector<AudioEmitter> audioEmitters;
   std::vector<AudioSource> audioSources;
 
-  int defaultScene = -1;
+  int defaultScene{-1};
   std::vector<std::string> extensionsUsed;
   std::vector<std::string> extensionsRequired;
 
@@ -7629,7 +7615,6 @@ static void SerializeGltfAudioSource(const AudioSource &source,
                                      detail::json &o) {
   std::string name;
   std::string uri;
-  int bufferView;        // (required if no uri)
   std::string mimeType;  // (required if no uri) ["audio/mp3", "audio/ogg",
                          // "audio/wav", "audio/m4a"]
 

--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -257,10 +257,8 @@ class Value {
   typedef std::map<std::string, Value> Object;
 
   Value()
-      : type_(NULL_TYPE),
-        int_value_(0),
-        real_value_(0.0),
-        boolean_value_(false) {}
+      
+        {}
 
   explicit Value(bool b) : type_(BOOL_TYPE) { boolean_value_ = b; }
   explicit Value(int i) : type_(INT_TYPE) {
@@ -521,8 +519,8 @@ typedef std::map<std::string, Parameter> ParameterMap;
 typedef std::map<std::string, Value> ExtensionMap;
 
 struct AnimationChannel {
-  int sampler;              // required
-  int target_node;          // optional index of the node to target (alternative
+  int sampler{-1};              // required
+  int target_node{-1};          // optional index of the node to target (alternative
                             // target should be provided by extension)
   std::string target_path;  // required with standard values of ["translation",
                             // "rotation", "scale", "weights"]
@@ -537,14 +535,14 @@ struct AnimationChannel {
   std::string target_extras_json_string;
   std::string target_extensions_json_string;
 
-  AnimationChannel() : sampler(-1), target_node(-1) {}
+  AnimationChannel()  {}
   DEFAULT_METHODS(AnimationChannel)
   bool operator==(const AnimationChannel &) const;
 };
 
 struct AnimationSampler {
-  int input;                  // required
-  int output;                 // required
+  int input{-1};                  // required
+  int output{-1};                 // required
   std::string interpolation;  // "LINEAR", "STEP","CUBICSPLINE" or user defined
                               // string. default "LINEAR"
   Value extras;
@@ -554,7 +552,7 @@ struct AnimationSampler {
   std::string extras_json_string;
   std::string extensions_json_string;
 
-  AnimationSampler() : input(-1), output(-1), interpolation("LINEAR") {}
+  AnimationSampler() :  interpolation("LINEAR") {}
   DEFAULT_METHODS(AnimationSampler)
   bool operator==(const AnimationSampler &) const;
 };
@@ -623,10 +621,8 @@ struct Sampler {
   std::string extensions_json_string;
 
   Sampler()
-      : minFilter(-1),
-        magFilter(-1),
-        wrapS(TINYGLTF_TEXTURE_WRAP_REPEAT),
-        wrapT(TINYGLTF_TEXTURE_WRAP_REPEAT) {}
+      
+        {}
   DEFAULT_METHODS(Sampler)
   bool operator==(const Sampler &) const;
 };
@@ -658,9 +654,9 @@ struct Image {
   // parsing) Default parser for Image does not provide as-is loading feature at
   // the moment. (You can manipulate this by providing your own LoadImageData
   // function)
-  bool as_is;
+  bool as_is{false};
 
-  Image() : as_is(false) {
+  Image()  {
     bufferView = -1;
     width = -1;
     height = -1;
@@ -676,8 +672,8 @@ struct Image {
 struct Texture {
   std::string name;
 
-  int sampler;
-  int source;
+  int sampler{-1};
+  int source{-1};
   Value extras;
   ExtensionMap extensions;
 
@@ -685,7 +681,7 @@ struct Texture {
   std::string extras_json_string;
   std::string extensions_json_string;
 
-  Texture() : sampler(-1), source(-1) {}
+  Texture()  {}
   DEFAULT_METHODS(Texture)
 
   bool operator==(const Texture &) const;
@@ -693,7 +689,7 @@ struct Texture {
 
 struct TextureInfo {
   int index = -1;  // required.
-  int texCoord;    // The set index of texture's TEXCOORD attribute used for
+  int texCoord{0};    // The set index of texture's TEXCOORD attribute used for
                    // texture coordinate mapping.
 
   Value extras;
@@ -703,16 +699,16 @@ struct TextureInfo {
   std::string extras_json_string;
   std::string extensions_json_string;
 
-  TextureInfo() : index(-1), texCoord(0) {}
+  TextureInfo()  {}
   DEFAULT_METHODS(TextureInfo)
   bool operator==(const TextureInfo &) const;
 };
 
 struct NormalTextureInfo {
   int index = -1;  // required
-  int texCoord;    // The set index of texture's TEXCOORD attribute used for
+  int texCoord{0};    // The set index of texture's TEXCOORD attribute used for
                    // texture coordinate mapping.
-  double scale;    // scaledNormal = normalize((<sampled normal texture value>
+  double scale{1.0};    // scaledNormal = normalize((<sampled normal texture value>
                    // * 2.0 - 1.0) * vec3(<normal scale>, <normal scale>, 1.0))
 
   Value extras;
@@ -722,16 +718,16 @@ struct NormalTextureInfo {
   std::string extras_json_string;
   std::string extensions_json_string;
 
-  NormalTextureInfo() : index(-1), texCoord(0), scale(1.0) {}
+  NormalTextureInfo()  {}
   DEFAULT_METHODS(NormalTextureInfo)
   bool operator==(const NormalTextureInfo &) const;
 };
 
 struct OcclusionTextureInfo {
   int index = -1;   // required
-  int texCoord;     // The set index of texture's TEXCOORD attribute used for
+  int texCoord{0};     // The set index of texture's TEXCOORD attribute used for
                     // texture coordinate mapping.
-  double strength;  // occludedColor = lerp(color, color * <sampled occlusion
+  double strength{1.0};  // occludedColor = lerp(color, color * <sampled occlusion
                     // texture value>, <occlusion strength>)
 
   Value extras;
@@ -741,7 +737,7 @@ struct OcclusionTextureInfo {
   std::string extras_json_string;
   std::string extensions_json_string;
 
-  OcclusionTextureInfo() : index(-1), texCoord(0), strength(1.0) {}
+  OcclusionTextureInfo()  {}
   DEFAULT_METHODS(OcclusionTextureInfo)
   bool operator==(const OcclusionTextureInfo &) const;
 };
@@ -750,8 +746,8 @@ struct OcclusionTextureInfo {
 struct PbrMetallicRoughness {
   std::vector<double> baseColorFactor;  // len = 4. default [1,1,1,1]
   TextureInfo baseColorTexture;
-  double metallicFactor;   // default 1
-  double roughnessFactor;  // default 1
+  double metallicFactor{1.0};   // default 1
+  double roughnessFactor{1.0};  // default 1
   TextureInfo metallicRoughnessTexture;
 
   Value extras;
@@ -762,9 +758,8 @@ struct PbrMetallicRoughness {
   std::string extensions_json_string;
 
   PbrMetallicRoughness()
-      : baseColorFactor(std::vector<double>{1.0, 1.0, 1.0, 1.0}),
-        metallicFactor(1.0),
-        roughnessFactor(1.0) {}
+      : baseColorFactor(std::vector<double>{1.0, 1.0, 1.0, 1.0})
+        {}
   DEFAULT_METHODS(PbrMetallicRoughness)
   bool operator==(const PbrMetallicRoughness &) const;
 };
@@ -777,8 +772,8 @@ struct Material {
 
   std::vector<double> emissiveFactor;  // length 3. default [0, 0, 0]
   std::string alphaMode;               // default "OPAQUE"
-  double alphaCutoff;                  // default 0.5
-  bool doubleSided;                    // default false;
+  double alphaCutoff{0.5};                  // default 0.5
+  bool doubleSided{false};                    // default false;
 
   PbrMetallicRoughness pbrMetallicRoughness;
 
@@ -798,7 +793,7 @@ struct Material {
   std::string extras_json_string;
   std::string extensions_json_string;
 
-  Material() : alphaMode("OPAQUE"), alphaCutoff(0.5), doubleSided(false) {}
+  Material() : alphaMode("OPAQUE") {}
   DEFAULT_METHODS(Material)
 
   bool operator==(const Material &) const;
@@ -823,25 +818,21 @@ struct BufferView {
   bool dracoDecoded{false};  // Flag indicating this has been draco decoded
 
   BufferView()
-      : buffer(-1),
-        byteOffset(0),
-        byteLength(0),
-        byteStride(0),
-        target(0),
-        dracoDecoded(false) {}
+      
+        {}
   DEFAULT_METHODS(BufferView)
   bool operator==(const BufferView &) const;
 };
 
 struct Accessor {
-  int bufferView;  // optional in spec but required here since sparse accessor
+  int bufferView{-1};  // optional in spec but required here since sparse accessor
                    // are not supported
   std::string name;
-  size_t byteOffset;
-  bool normalized;    // optional.
-  int componentType;  // (required) One of TINYGLTF_COMPONENT_TYPE_***
-  size_t count;       // required
-  int type;           // (required) One of TINYGLTF_TYPE_***   ..
+  size_t byteOffset{0};
+  bool normalized{false};    // optional.
+  int componentType{-1};  // (required) One of TINYGLTF_COMPONENT_TYPE_***
+  size_t count{0};       // required
+  int type{-1};           // (required) One of TINYGLTF_TYPE_***   ..
   Value extras;
   ExtensionMap extensions;
 
@@ -920,12 +911,8 @@ struct Accessor {
   }
 
   Accessor()
-      : bufferView(-1),
-        byteOffset(0),
-        normalized(false),
-        componentType(-1),
-        count(0),
-        type(-1) {
+      
+        {
     sparse.isSparse = false;
   }
   DEFAULT_METHODS(Accessor)
@@ -933,17 +920,14 @@ struct Accessor {
 };
 
 struct PerspectiveCamera {
-  double aspectRatio;  // min > 0
-  double yfov;         // required. min > 0
-  double zfar;         // min > 0
-  double znear;        // required. min > 0
+  double aspectRatio{0.0};  // min > 0
+  double yfov{0.0};         // required. min > 0
+  double zfar{0.0};         // min > 0
+  double znear{0.0};        // required. min > 0
 
   PerspectiveCamera()
-      : aspectRatio(0.0),
-        yfov(0.0),
-        zfar(0.0)  // 0 = use infinite projection matrix
-        ,
-        znear(0.0) {}
+      
+        {}
   DEFAULT_METHODS(PerspectiveCamera)
   bool operator==(const PerspectiveCamera &) const;
 
@@ -956,12 +940,12 @@ struct PerspectiveCamera {
 };
 
 struct OrthographicCamera {
-  double xmag;   // required. must not be zero.
-  double ymag;   // required. must not be zero.
-  double zfar;   // required. `zfar` must be greater than `znear`.
-  double znear;  // required
+  double xmag{0.0};   // required. must not be zero.
+  double ymag{0.0};   // required. must not be zero.
+  double zfar{0.0};   // required. `zfar` must be greater than `znear`.
+  double znear{0.0};  // required
 
-  OrthographicCamera() : xmag(0.0), ymag(0.0), zfar(0.0), znear(0.0) {}
+  OrthographicCamera()  {}
   DEFAULT_METHODS(OrthographicCamera)
   bool operator==(const OrthographicCamera &) const;
 
@@ -1039,7 +1023,7 @@ struct Mesh {
 
 class Node {
  public:
-  Node() : camera(-1), skin(-1), mesh(-1), light(-1), emitter(-1) {}
+  Node()  {}
 
   DEFAULT_METHODS(Node)
 
@@ -1120,10 +1104,10 @@ struct Scene {
 };
 
 struct SpotLight {
-  double innerConeAngle;
-  double outerConeAngle;
+  double innerConeAngle{0.0};
+  double outerConeAngle{0.7853981634};
 
-  SpotLight() : innerConeAngle(0.0), outerConeAngle(0.7853981634) {}
+  SpotLight()  {}
   DEFAULT_METHODS(SpotLight)
   bool operator==(const SpotLight &) const;
 
@@ -1143,7 +1127,7 @@ struct Light {
   double range{0.0};  // 0.0 = infinite
   SpotLight spot;
 
-  Light() : intensity(1.0), range(0.0) {}
+  Light()  {}
   DEFAULT_METHODS(Light)
 
   bool operator==(const Light &) const;
@@ -1164,7 +1148,7 @@ struct PositionalEmitter {
   double refDistance{1.0};
   double rolloffFactor{1.0};
 
-  PositionalEmitter() : coneInnerAngle(6.283185307179586), coneOuterAngle(6.283185307179586) {}
+  PositionalEmitter()  {}
   DEFAULT_METHODS(PositionalEmitter)
   bool operator==(const PositionalEmitter &) const;
 
@@ -1205,9 +1189,7 @@ struct AudioEmitter {
   int source{-1};
 
   AudioEmitter()
-      : gain(1.0),
-        loop(false),
-        playing(false),
+      : 
         type("global"),
         distanceModel("inverse") {}
   DEFAULT_METHODS(AudioEmitter)
@@ -1438,7 +1420,7 @@ class TinyGLTF {
 #pragma clang diagnostic ignored "-Wc++98-compat"
 #endif
 
-  TinyGLTF() : bin_data_(nullptr), bin_size_(0), is_binary_(false) {}
+  TinyGLTF()  {}
 
 #ifdef __clang__
 #pragma clang diagnostic pop

--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -48,8 +48,9 @@
 #include <string>
 #include <vector>
 
-//Auto-detect C++14 standard version
-#if !defined(TINYGLTF_USE_CPP14) && defined(__cplusplus) && (__cplusplus >= 201402L)
+// Auto-detect C++14 standard version
+#if !defined(TINYGLTF_USE_CPP14) && defined(__cplusplus) && \
+    (__cplusplus >= 201402L)
 #define TINYGLTF_USE_CPP14
 #endif
 
@@ -256,9 +257,7 @@ class Value {
   typedef std::vector<Value> Array;
   typedef std::map<std::string, Value> Object;
 
-  Value()
-      
-        {}
+  Value() = default;
 
   explicit Value(bool b) : type_(BOOL_TYPE) { boolean_value_ = b; }
   explicit Value(int i) : type_(INT_TYPE) {
@@ -271,9 +270,7 @@ class Value {
   }
   explicit Value(std::string &&s)
       : type_(STRING_TYPE), string_value_(std::move(s)) {}
-  explicit Value(const char *s) : type_(STRING_TYPE) {
-    string_value_ = s;
-  }
+  explicit Value(const char *s) : type_(STRING_TYPE) { string_value_ = s; }
   explicit Value(const unsigned char *p, size_t n) : type_(BINARY_TYPE) {
     binary_value_.resize(n);
     memcpy(binary_value_.data(), p, n);
@@ -519,8 +516,8 @@ typedef std::map<std::string, Parameter> ParameterMap;
 typedef std::map<std::string, Value> ExtensionMap;
 
 struct AnimationChannel {
-  int sampler{-1};              // required
-  int target_node{-1};          // optional index of the node to target (alternative
+  int sampler{-1};          // required
+  int target_node{-1};      // optional index of the node to target (alternative
                             // target should be provided by extension)
   std::string target_path;  // required with standard values of ["translation",
                             // "rotation", "scale", "weights"]
@@ -535,14 +532,14 @@ struct AnimationChannel {
   std::string target_extras_json_string;
   std::string target_extensions_json_string;
 
-  AnimationChannel()  {}
+  AnimationChannel() = default;
   DEFAULT_METHODS(AnimationChannel)
   bool operator==(const AnimationChannel &) const;
 };
 
 struct AnimationSampler {
-  int input{-1};                  // required
-  int output{-1};                 // required
+  int input{-1};              // required
+  int output{-1};             // required
   std::string interpolation;  // "LINEAR", "STEP","CUBICSPLINE" or user defined
                               // string. default "LINEAR"
   Value extras;
@@ -552,7 +549,7 @@ struct AnimationSampler {
   std::string extras_json_string;
   std::string extensions_json_string;
 
-  AnimationSampler() :  interpolation("LINEAR") {}
+  AnimationSampler() : interpolation("LINEAR") {}
   DEFAULT_METHODS(AnimationSampler)
   bool operator==(const AnimationSampler &) const;
 };
@@ -620,9 +617,7 @@ struct Sampler {
   std::string extras_json_string;
   std::string extensions_json_string;
 
-  Sampler()
-      
-        {}
+  Sampler() = default;
   DEFAULT_METHODS(Sampler)
   bool operator==(const Sampler &) const;
 };
@@ -656,7 +651,7 @@ struct Image {
   // function)
   bool as_is{false};
 
-  Image()  {
+  Image() {
     bufferView = -1;
     width = -1;
     height = -1;
@@ -681,16 +676,16 @@ struct Texture {
   std::string extras_json_string;
   std::string extensions_json_string;
 
-  Texture()  {}
+  Texture() = default;
   DEFAULT_METHODS(Texture)
 
   bool operator==(const Texture &) const;
 };
 
 struct TextureInfo {
-  int index = -1;  // required.
-  int texCoord{0};    // The set index of texture's TEXCOORD attribute used for
-                   // texture coordinate mapping.
+  int index{-1};    // required.
+  int texCoord{0};  // The set index of texture's TEXCOORD attribute used for
+                    // texture coordinate mapping.
 
   Value extras;
   ExtensionMap extensions;
@@ -699,17 +694,18 @@ struct TextureInfo {
   std::string extras_json_string;
   std::string extensions_json_string;
 
-  TextureInfo()  {}
+  TextureInfo() = default;
   DEFAULT_METHODS(TextureInfo)
   bool operator==(const TextureInfo &) const;
 };
 
 struct NormalTextureInfo {
-  int index = -1;  // required
-  int texCoord{0};    // The set index of texture's TEXCOORD attribute used for
-                   // texture coordinate mapping.
-  double scale{1.0};    // scaledNormal = normalize((<sampled normal texture value>
-                   // * 2.0 - 1.0) * vec3(<normal scale>, <normal scale>, 1.0))
+  int index{-1};    // required
+  int texCoord{0};  // The set index of texture's TEXCOORD attribute used for
+                    // texture coordinate mapping.
+  double scale{
+      1.0};  // scaledNormal = normalize((<sampled normal texture value>
+             // * 2.0 - 1.0) * vec3(<normal scale>, <normal scale>, 1.0))
 
   Value extras;
   ExtensionMap extensions;
@@ -718,17 +714,17 @@ struct NormalTextureInfo {
   std::string extras_json_string;
   std::string extensions_json_string;
 
-  NormalTextureInfo()  {}
+  NormalTextureInfo() = default;
   DEFAULT_METHODS(NormalTextureInfo)
   bool operator==(const NormalTextureInfo &) const;
 };
 
 struct OcclusionTextureInfo {
-  int index = -1;   // required
-  int texCoord{0};     // The set index of texture's TEXCOORD attribute used for
+  int index{-1};    // required
+  int texCoord{0};  // The set index of texture's TEXCOORD attribute used for
                     // texture coordinate mapping.
-  double strength{1.0};  // occludedColor = lerp(color, color * <sampled occlusion
-                    // texture value>, <occlusion strength>)
+  double strength{1.0};  // occludedColor = lerp(color, color * <sampled
+                         // occlusion texture value>, <occlusion strength>)
 
   Value extras;
   ExtensionMap extensions;
@@ -737,7 +733,7 @@ struct OcclusionTextureInfo {
   std::string extras_json_string;
   std::string extensions_json_string;
 
-  OcclusionTextureInfo()  {}
+  OcclusionTextureInfo() = default;
   DEFAULT_METHODS(OcclusionTextureInfo)
   bool operator==(const OcclusionTextureInfo &) const;
 };
@@ -758,8 +754,7 @@ struct PbrMetallicRoughness {
   std::string extensions_json_string;
 
   PbrMetallicRoughness()
-      : baseColorFactor(std::vector<double>{1.0, 1.0, 1.0, 1.0})
-        {}
+      : baseColorFactor(std::vector<double>{1.0, 1.0, 1.0, 1.0}) {}
   DEFAULT_METHODS(PbrMetallicRoughness)
   bool operator==(const PbrMetallicRoughness &) const;
 };
@@ -772,8 +767,8 @@ struct Material {
 
   std::vector<double> emissiveFactor;  // length 3. default [0, 0, 0]
   std::string alphaMode;               // default "OPAQUE"
-  double alphaCutoff{0.5};                  // default 0.5
-  bool doubleSided{false};                    // default false;
+  double alphaCutoff{0.5};             // default 0.5
+  bool doubleSided{false};             // default false;
 
   PbrMetallicRoughness pbrMetallicRoughness;
 
@@ -817,22 +812,20 @@ struct BufferView {
 
   bool dracoDecoded{false};  // Flag indicating this has been draco decoded
 
-  BufferView()
-      
-        {}
+  BufferView() = default;
   DEFAULT_METHODS(BufferView)
   bool operator==(const BufferView &) const;
 };
 
 struct Accessor {
-  int bufferView{-1};  // optional in spec but required here since sparse accessor
-                   // are not supported
+  int bufferView{-1};  // optional in spec but required here since sparse
+                       // accessor are not supported
   std::string name;
   size_t byteOffset{0};
-  bool normalized{false};    // optional.
-  int componentType{-1};  // (required) One of TINYGLTF_COMPONENT_TYPE_***
-  size_t count{0};       // required
-  int type{-1};           // (required) One of TINYGLTF_TYPE_***   ..
+  bool normalized{false};  // optional.
+  int componentType{-1};   // (required) One of TINYGLTF_COMPONENT_TYPE_***
+  size_t count{0};         // required
+  int type{-1};            // (required) One of TINYGLTF_TYPE_***   ..
   Value extras;
   ExtensionMap extensions;
 
@@ -893,8 +886,8 @@ struct Accessor {
 
       return componentSizeInBytes * numComponents;
     } else {
-      // Check if byteStride is a multiple of the size of the accessor's component
-      // type.
+      // Check if byteStride is a multiple of the size of the accessor's
+      // component type.
       int componentSizeInBytes =
           GetComponentSizeInBytes(static_cast<uint32_t>(componentType));
       if (componentSizeInBytes <= 0) {
@@ -911,8 +904,8 @@ struct Accessor {
   }
 
   Accessor()
-      
-        {
+
+  {
     sparse.isSparse = false;
   }
   DEFAULT_METHODS(Accessor)
@@ -925,9 +918,7 @@ struct PerspectiveCamera {
   double zfar{0.0};         // min > 0
   double znear{0.0};        // required. min > 0
 
-  PerspectiveCamera()
-      
-        {}
+  PerspectiveCamera() = default;
   DEFAULT_METHODS(PerspectiveCamera)
   bool operator==(const PerspectiveCamera &) const;
 
@@ -945,7 +936,7 @@ struct OrthographicCamera {
   double zfar{0.0};   // required. `zfar` must be greater than `znear`.
   double znear{0.0};  // required
 
-  OrthographicCamera()  {}
+  OrthographicCamera() = default;
   DEFAULT_METHODS(OrthographicCamera)
   bool operator==(const OrthographicCamera &) const;
 
@@ -964,7 +955,7 @@ struct Camera {
   PerspectiveCamera perspective;
   OrthographicCamera orthographic;
 
-  Camera() {}
+  Camera() = default;
   DEFAULT_METHODS(Camera)
   bool operator==(const Camera &) const;
 
@@ -1023,7 +1014,7 @@ struct Mesh {
 
 class Node {
  public:
-  Node()  {}
+  Node() = default;
 
   DEFAULT_METHODS(Node)
 
@@ -1034,8 +1025,8 @@ class Node {
   std::string name;
   int skin{-1};
   int mesh{-1};
-  int light{-1};  // light source index (KHR_lights_punctual)
-  int emitter{-1}; // audio emitter index (KHR_audio)
+  int light{-1};    // light source index (KHR_lights_punctual)
+  int emitter{-1};  // audio emitter index (KHR_audio)
   std::vector<int> children;
   std::vector<double> rotation;     // length must be 0 or 4
   std::vector<double> scale;        // length must be 0 or 3
@@ -1089,7 +1080,7 @@ struct Asset {
 struct Scene {
   std::string name;
   std::vector<int> nodes;
-  std::vector<int> audioEmitters; // KHR_audio global emitters
+  std::vector<int> audioEmitters;  // KHR_audio global emitters
 
   ExtensionMap extensions;
   Value extras;
@@ -1107,7 +1098,7 @@ struct SpotLight {
   double innerConeAngle{0.0};
   double outerConeAngle{0.7853981634};
 
-  SpotLight()  {}
+  SpotLight() = default;
   DEFAULT_METHODS(SpotLight)
   bool operator==(const SpotLight &) const;
 
@@ -1127,7 +1118,7 @@ struct Light {
   double range{0.0};  // 0.0 = infinite
   SpotLight spot;
 
-  Light()  {}
+  Light() = default;
   DEFAULT_METHODS(Light)
 
   bool operator==(const Light &) const;
@@ -1148,7 +1139,7 @@ struct PositionalEmitter {
   double refDistance{1.0};
   double rolloffFactor{1.0};
 
-  PositionalEmitter()  {}
+  PositionalEmitter() = default;
   DEFAULT_METHODS(PositionalEmitter)
   bool operator==(const PositionalEmitter &) const;
 
@@ -1188,10 +1179,7 @@ struct AudioEmitter {
   PositionalEmitter positional;
   int source{-1};
 
-  AudioEmitter()
-      : 
-        type("global"),
-        distanceModel("inverse") {}
+  AudioEmitter() : type("global"), distanceModel("inverse") {}
   DEFAULT_METHODS(AudioEmitter)
 
   bool operator==(const AudioEmitter &) const;
@@ -1205,24 +1193,25 @@ struct AudioEmitter {
 };
 
 struct AudioSource {
-    std::string name;
-    std::string uri;
-    int bufferView{-1};  // (required if no uri)
-    std::string mimeType;  // (required if no uri) The audio's MIME type. Required if
-                   // bufferView is defined. Unless specified by another
-                   // extension, the only supported mimeType is audio/mpeg.
+  std::string name;
+  std::string uri;
+  int bufferView{-1};  // (required if no uri)
+  std::string
+      mimeType;  // (required if no uri) The audio's MIME type. Required if
+                 // bufferView is defined. Unless specified by another
+                 // extension, the only supported mimeType is audio/mpeg.
 
-    AudioSource() {}
-    DEFAULT_METHODS(AudioSource)
+  AudioSource() = default;
+  DEFAULT_METHODS(AudioSource)
 
-    bool operator==(const AudioSource &) const;
+  bool operator==(const AudioSource &) const;
 
-    Value extras;
-    ExtensionMap extensions;
+  Value extras;
+  ExtensionMap extensions;
 
-    // Filled when SetStoreOriginalJSONForExtrasAndExtensions is enabled.
-    std::string extras_json_string;
-    std::string extensions_json_string;
+  // Filled when SetStoreOriginalJSONForExtrasAndExtensions is enabled.
+  std::string extras_json_string;
+  std::string extensions_json_string;
 };
 
 class Model {
@@ -1369,7 +1358,8 @@ typedef bool (*WriteWholeFileFunction)(std::string *, const std::string &,
 ///
 /// GetFileSizeFunction type. Signature for custom filesystem callbacks.
 ///
-typedef bool (*GetFileSizeFunction)(size_t *filesize_out, std::string *err, const std::string &abs_filename,
+typedef bool (*GetFileSizeFunction)(size_t *filesize_out, std::string *err,
+                                    const std::string &abs_filename,
                                     void *userdata);
 
 ///
@@ -1381,7 +1371,8 @@ struct FsCallbacks {
   ExpandFilePathFunction ExpandFilePath;
   ReadWholeFileFunction ReadWholeFile;
   WriteWholeFileFunction WriteWholeFile;
-  GetFileSizeFunction GetFileSizeInBytes; // To avoid GetFileSize Win32 API, add `InBytes` suffix.
+  GetFileSizeFunction GetFileSizeInBytes;  // To avoid GetFileSize Win32 API,
+                                           // add `InBytes` suffix.
 
   void *user_data;  // An argument that is passed to all fs callbacks
 };
@@ -1406,8 +1397,8 @@ bool ReadWholeFile(std::vector<unsigned char> *out, std::string *err,
 bool WriteWholeFile(std::string *err, const std::string &filepath,
                     const std::vector<unsigned char> &contents, void *);
 
-bool GetFileSizeInBytes(size_t *filesize_out, std::string *err, const std::string &filepath,
-                    void *);
+bool GetFileSizeInBytes(size_t *filesize_out, std::string *err,
+                        const std::string &filepath, void *);
 #endif
 
 ///
@@ -1420,13 +1411,13 @@ class TinyGLTF {
 #pragma clang diagnostic ignored "-Wc++98-compat"
 #endif
 
-  TinyGLTF()  {}
+  TinyGLTF() = default;
 
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif
 
-  ~TinyGLTF() {}
+  ~TinyGLTF() = default;
 
   ///
   /// Loads glTF ASCII asset from a file.
@@ -1556,9 +1547,7 @@ class TinyGLTF {
     max_external_file_size_ = max_bytes;
   }
 
-  size_t GetMaxExternalFileSize() const {
-    return max_external_file_size_;
-  }
+  size_t GetMaxExternalFileSize() const { return max_external_file_size_; }
 
   bool GetPreserveImageChannels() const { return preserve_image_channels_; }
 
@@ -1584,7 +1573,8 @@ class TinyGLTF {
   bool preserve_image_channels_ = false;  /// Default false(expand channels to
                                           /// RGBA) for backward compatibility.
 
-  size_t max_external_file_size_{size_t((std::numeric_limits<int32_t>::max)())}; // Default 2GB
+  size_t max_external_file_size_{
+      size_t((std::numeric_limits<int32_t>::max)())};  // Default 2GB
 
   // Warning & error messages
   std::string warn_;
@@ -1592,8 +1582,11 @@ class TinyGLTF {
 
   FsCallbacks fs = {
 #ifndef TINYGLTF_NO_FS
-      &tinygltf::FileExists, &tinygltf::ExpandFilePath,
-      &tinygltf::ReadWholeFile, &tinygltf::WriteWholeFile, &tinygltf::GetFileSizeInBytes,
+      &tinygltf::FileExists,
+      &tinygltf::ExpandFilePath,
+      &tinygltf::ReadWholeFile,
+      &tinygltf::WriteWholeFile,
+      &tinygltf::GetFileSizeInBytes,
 
       nullptr  // Fs callback user data
 #else
@@ -1640,11 +1633,12 @@ class TinyGLTF {
 
 #if defined(TINYGLTF_IMPLEMENTATION) || defined(__INTELLISENSE__)
 #include <algorithm>
-//#include <cassert>
+// #include <cassert>
 #ifndef TINYGLTF_NO_FS
+#include <sys/stat.h>  // for is_directory check
+
 #include <cstdio>
 #include <fstream>
-#include <sys/stat.h> // for is_directory check
 #endif
 #include <sstream>
 
@@ -1785,7 +1779,7 @@ class TinyGLTF {
 #endif
 
 #elif !defined(__ANDROID__) && !defined(__OpenBSD__)
-//#include <wordexp.h>
+// #include <wordexp.h>
 #endif
 
 #if defined(__sparcv9) || defined(__powerpc__)
@@ -1879,8 +1873,8 @@ void JsonParse(JsonDocument &doc, const char *str, size_t length,
   doc = detail::json::parse(str, str + length, nullptr, throwExc);
 #endif
 }
-}  // namespace
-}
+}  // namespace detail
+}  // namespace tinygltf
 
 #ifdef __APPLE__
 #include "TargetConditionals.h"
@@ -2024,12 +2018,14 @@ bool Light::operator==(const Light &other) const {
          this->type == other.type;
 }
 bool AudioEmitter::operator==(const AudioEmitter &other) const {
-  return this->name == other.name && TINYGLTF_DOUBLE_EQUAL(this->gain, other.gain) &&
+  return this->name == other.name &&
+         TINYGLTF_DOUBLE_EQUAL(this->gain, other.gain) &&
          this->loop == other.loop && this->playing == other.playing &&
-         this->type == other.type && this->distanceModel == other.distanceModel &&
+         this->type == other.type &&
+         this->distanceModel == other.distanceModel &&
          this->source == other.source;
 }
-bool AudioSource::operator == (const AudioSource &other) const {
+bool AudioSource::operator==(const AudioSource &other) const {
   return this->name == other.name && this->uri == other.uri;
 }
 bool Material::operator==(const Material &other) const {
@@ -2071,8 +2067,7 @@ bool Node::operator==(const Node &other) const {
   return this->camera == other.camera && this->children == other.children &&
          this->extensions == other.extensions && this->extras == other.extras &&
          Equals(this->matrix, other.matrix) && this->mesh == other.mesh &&
-         (this->light == other.light) &&
-         (this->emitter == other.emitter) &&
+         (this->light == other.light) && (this->emitter == other.emitter) &&
          this->name == other.name && Equals(this->rotation, other.rotation) &&
          Equals(this->scale, other.scale) && this->skin == other.skin &&
          Equals(this->translation, other.translation) &&
@@ -2083,14 +2078,14 @@ bool SpotLight::operator==(const SpotLight &other) const {
          TINYGLTF_DOUBLE_EQUAL(this->innerConeAngle, other.innerConeAngle) &&
          TINYGLTF_DOUBLE_EQUAL(this->outerConeAngle, other.outerConeAngle);
 }
-bool PositionalEmitter::operator == (const PositionalEmitter& other) const {
-    return this->extensions == other.extensions && this->extras == other.extras &&
-        TINYGLTF_DOUBLE_EQUAL(this->coneInnerAngle, other.coneInnerAngle) &&
-        TINYGLTF_DOUBLE_EQUAL(this->coneOuterAngle, other.coneOuterAngle) &&
-        TINYGLTF_DOUBLE_EQUAL(this->coneOuterGain, other.coneOuterGain) &&
-        TINYGLTF_DOUBLE_EQUAL(this->maxDistance, other.maxDistance) &&
-        TINYGLTF_DOUBLE_EQUAL(this->refDistance, other.refDistance) &&
-        TINYGLTF_DOUBLE_EQUAL(this->rolloffFactor, other.rolloffFactor);
+bool PositionalEmitter::operator==(const PositionalEmitter &other) const {
+  return this->extensions == other.extensions && this->extras == other.extras &&
+         TINYGLTF_DOUBLE_EQUAL(this->coneInnerAngle, other.coneInnerAngle) &&
+         TINYGLTF_DOUBLE_EQUAL(this->coneOuterAngle, other.coneOuterAngle) &&
+         TINYGLTF_DOUBLE_EQUAL(this->coneOuterGain, other.coneOuterGain) &&
+         TINYGLTF_DOUBLE_EQUAL(this->maxDistance, other.maxDistance) &&
+         TINYGLTF_DOUBLE_EQUAL(this->refDistance, other.refDistance) &&
+         TINYGLTF_DOUBLE_EQUAL(this->rolloffFactor, other.rolloffFactor);
 }
 bool OrthographicCamera::operator==(const OrthographicCamera &other) const {
   return this->extensions == other.extensions && this->extras == other.extras &&
@@ -2222,8 +2217,9 @@ static std::string FindFile(const std::vector<std::string> &paths,
   }
 
   // https://github.com/syoyo/tinygltf/issues/416
-  // Use strlen() since std::string's size/length reports the number of elements in the buffer, not the length of string(null-terminated)
-  // strip null-character in the middle of string.
+  // Use strlen() since std::string's size/length reports the number of elements
+  // in the buffer, not the length of string(null-terminated) strip
+  // null-character in the middle of string.
   size_t slength = strlen(filepath.c_str());
   if (slength == 0) {
     return std::string();
@@ -2479,7 +2475,8 @@ bool URIDecode(const std::string &in_uri, std::string *out_uri,
 static bool LoadExternalFile(std::vector<unsigned char> *out, std::string *err,
                              std::string *warn, const std::string &filename,
                              const std::string &basedir, bool required,
-                             size_t reqBytes, bool checkSize, size_t maxFileSize, FsCallbacks *fs) {
+                             size_t reqBytes, bool checkSize,
+                             size_t maxFileSize, FsCallbacks *fs) {
   if (fs == nullptr || fs->FileExists == nullptr ||
       fs->ExpandFilePath == nullptr || fs->ReadWholeFile == nullptr) {
     // This is a developer error, assert() ?
@@ -2507,14 +2504,15 @@ static bool LoadExternalFile(std::vector<unsigned char> *out, std::string *err,
 
   // Check file size
   if (fs->GetFileSizeInBytes) {
-
     size_t file_size{0};
     std::string _err;
-    bool ok = fs->GetFileSizeInBytes(&file_size, &_err, filepath, fs->user_data);
+    bool ok =
+        fs->GetFileSizeInBytes(&file_size, &_err, filepath, fs->user_data);
     if (!ok) {
       if (_err.size()) {
         if (failMsgOut) {
-          (*failMsgOut) += "Getting file size failed : " + filename + ", err = " + _err + "\n";
+          (*failMsgOut) += "Getting file size failed : " + filename +
+                           ", err = " + _err + "\n";
         }
       }
       return false;
@@ -2522,7 +2520,9 @@ static bool LoadExternalFile(std::vector<unsigned char> *out, std::string *err,
 
     if (file_size > maxFileSize) {
       if (failMsgOut) {
-        (*failMsgOut) += "File size " + std::to_string(file_size) + " exceeds maximum allowed file size " + std::to_string(maxFileSize) + " : " + filepath + "\n";
+        (*failMsgOut) += "File size " + std::to_string(file_size) +
+                         " exceeds maximum allowed file size " +
+                         std::to_string(maxFileSize) + " : " + filepath + "\n";
       }
       return false;
     }
@@ -2753,8 +2753,8 @@ bool WriteImageData(const std::string *basepath, const std::string *filename,
   if (embedImages) {
     // Embed base64-encoded image into URI
     if (data.size()) {
-      *out_uri = header +
-                base64_encode(&data[0], static_cast<unsigned int>(data.size()));
+      *out_uri = header + base64_encode(&data[0],
+                                        static_cast<unsigned int>(data.size()));
     } else {
       // Throw error?
     }
@@ -2944,7 +2944,7 @@ std::string ExpandFilePath(const std::string &filepath, void *) {
 }
 
 bool GetFileSizeInBytes(size_t *filesize_out, std::string *err,
-                   const std::string &filepath, void *userdata) {
+                        const std::string &filepath, void *userdata) {
   (void)userdata;
 
 #ifdef TINYGLTF_ANDROID_LOAD_FROM_ASSETS
@@ -3003,7 +3003,9 @@ bool GetFileSizeInBytes(size_t *filesize_out, std::string *err,
   f.peek();
   if (!f) {
     if (err) {
-      (*err) += "File read error. Maybe empty file or invalid file : " + filepath + "\n";
+      (*err) +=
+          "File read error. Maybe empty file or invalid file : " + filepath +
+          "\n";
     }
     return false;
   }
@@ -3011,7 +3013,7 @@ bool GetFileSizeInBytes(size_t *filesize_out, std::string *err,
   f.seekg(0, f.end);
   size_t sz = static_cast<size_t>(f.tellg());
 
-  //std::cout << "sz = " << sz << "\n";
+  // std::cout << "sz = " << sz << "\n";
   f.seekg(0, f.beg);
 
   if (int64_t(sz) < 0) {
@@ -3096,7 +3098,9 @@ bool ReadWholeFile(std::vector<unsigned char> *out, std::string *err,
   f.peek();
   if (!f) {
     if (err) {
-      (*err) += "File read error. Maybe empty file or invalid file : " + filepath + "\n";
+      (*err) +=
+          "File read error. Maybe empty file or invalid file : " + filepath +
+          "\n";
     }
     return false;
   }
@@ -3104,7 +3108,7 @@ bool ReadWholeFile(std::vector<unsigned char> *out, std::string *err,
   f.seekg(0, f.end);
   size_t sz = static_cast<size_t>(f.tellg());
 
-  //std::cout << "sz = " << sz << "\n";
+  // std::cout << "sz = " << sz << "\n";
   f.seekg(0, f.beg);
 
   if (int64_t(sz) < 0) {
@@ -3483,7 +3487,8 @@ std::string GetKey(detail::json_const_iterator &it) {
 #endif
 }
 
-bool FindMember(const detail::json &o, const char *member, detail::json_const_iterator &it) {
+bool FindMember(const detail::json &o, const char *member,
+                detail::json_const_iterator &it) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   if (!o.IsObject()) {
     return false;
@@ -3496,7 +3501,8 @@ bool FindMember(const detail::json &o, const char *member, detail::json_const_it
 #endif
 }
 
-bool FindMember(detail::json &o, const char *member, detail::json_iterator &it) {
+bool FindMember(detail::json &o, const char *member,
+                detail::json_iterator &it) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   if (!o.IsObject()) {
     return false;
@@ -3509,7 +3515,7 @@ bool FindMember(detail::json &o, const char *member, detail::json_iterator &it) 
 #endif
 }
 
-void Erase(detail::json & o, detail::json_iterator &it) {
+void Erase(detail::json &o, detail::json_iterator &it) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   o.EraseMember(it);
 #else
@@ -3517,7 +3523,7 @@ void Erase(detail::json & o, detail::json_iterator &it) {
 #endif
 }
 
-bool IsEmpty(const detail::json & o) {
+bool IsEmpty(const detail::json &o) {
 #ifdef TINYGLTF_USE_RAPIDJSON
   return o.ObjectEmpty();
 #else
@@ -3565,7 +3571,7 @@ std::string JsonToString(const detail::json &o, int spacing = -1) {
 #endif
 }
 
-}  // namespace
+}  // namespace detail
 
 static bool ParseJsonAsValue(Value *ret, const detail::json &o) {
   Value val{};
@@ -3674,7 +3680,8 @@ static bool ParseExtrasProperty(Value *ret, const detail::json &o) {
   return ParseJsonAsValue(ret, detail::GetValue(it));
 }
 
-static bool ParseBooleanProperty(bool *ret, std::string *err, const detail::json &o,
+static bool ParseBooleanProperty(bool *ret, std::string *err,
+                                 const detail::json &o,
                                  const std::string &property,
                                  const bool required,
                                  const std::string &parent_node = "") {
@@ -3723,7 +3730,8 @@ static bool ParseBooleanProperty(bool *ret, std::string *err, const detail::json
   return true;
 }
 
-static bool ParseIntegerProperty(int *ret, std::string *err, const detail::json &o,
+static bool ParseIntegerProperty(int *ret, std::string *err,
+                                 const detail::json &o,
                                  const std::string &property,
                                  const bool required,
                                  const std::string &parent_node = "") {
@@ -3759,7 +3767,8 @@ static bool ParseIntegerProperty(int *ret, std::string *err, const detail::json 
   return true;
 }
 
-static bool ParseUnsignedProperty(size_t *ret, std::string *err, const detail::json &o,
+static bool ParseUnsignedProperty(size_t *ret, std::string *err,
+                                  const detail::json &o,
                                   const std::string &property,
                                   const bool required,
                                   const std::string &parent_node = "") {
@@ -3812,7 +3821,8 @@ static bool ParseUnsignedProperty(size_t *ret, std::string *err, const detail::j
   return true;
 }
 
-static bool ParseNumberProperty(double *ret, std::string *err, const detail::json &o,
+static bool ParseNumberProperty(double *ret, std::string *err,
+                                const detail::json &o,
                                 const std::string &property,
                                 const bool required,
                                 const std::string &parent_node = "") {
@@ -3851,8 +3861,8 @@ static bool ParseNumberProperty(double *ret, std::string *err, const detail::jso
 }
 
 static bool ParseNumberArrayProperty(std::vector<double> *ret, std::string *err,
-                                     const detail::json &o, const std::string &property,
-                                     bool required,
+                                     const detail::json &o,
+                                     const std::string &property, bool required,
                                      const std::string &parent_node = "") {
   detail::json_const_iterator it;
   if (!detail::FindMember(o, property.c_str(), it)) {
@@ -4087,8 +4097,8 @@ static bool ParseJSONProperty(std::map<std::string, double> *ret,
 }
 
 static bool ParseParameterProperty(Parameter *param, std::string *err,
-                                   const detail::json &o, const std::string &prop,
-                                   bool required) {
+                                   const detail::json &o,
+                                   const std::string &prop, bool required) {
   // A parameter value can either be a string or an array of either a boolean or
   // a number. Booleans of any kind aren't supported here. Granted, it
   // complicates the Parameter structure and breaks it semantically in the sense
@@ -4133,7 +4143,8 @@ static bool ParseExtensionsProperty(ExtensionMap *ret, std::string *err,
     return false;
   }
   ExtensionMap extensions;
-  detail::json_const_iterator extIt = detail::ObjectBegin(obj);  // it.value().begin();
+  detail::json_const_iterator extIt =
+      detail::ObjectBegin(obj);  // it.value().begin();
   detail::json_const_iterator extEnd = detail::ObjectEnd(obj);
   for (; extIt != extEnd; ++extIt) {
     auto &itObj = detail::GetValue(extIt);
@@ -4154,9 +4165,9 @@ static bool ParseExtensionsProperty(ExtensionMap *ret, std::string *err,
 }
 
 template <typename GltfType>
-static bool ParseExtrasAndExtensions(GltfType * target, std::string *err,
-    const detail::json & o, bool store_json_strings) {
-
+static bool ParseExtrasAndExtensions(GltfType *target, std::string *err,
+                                     const detail::json &o,
+                                     bool store_json_strings) {
   ParseExtensionsProperty(&target->extensions, err, o);
   ParseExtrasProperty(&target->extras, o);
 
@@ -4164,7 +4175,8 @@ static bool ParseExtrasAndExtensions(GltfType * target, std::string *err,
     {
       detail::json_const_iterator it;
       if (detail::FindMember(o, "extensions", it)) {
-        target->extensions_json_string = detail::JsonToString(detail::GetValue(it));
+        target->extensions_json_string =
+            detail::JsonToString(detail::GetValue(it));
       }
     }
     {
@@ -4184,15 +4196,16 @@ static bool ParseAsset(Asset *asset, std::string *err, const detail::json &o,
   ParseStringProperty(&asset->minVersion, err, o, "minVersion", false, "Asset");
   ParseStringProperty(&asset->copyright, err, o, "copyright", false, "Asset");
 
-  ParseExtrasAndExtensions(asset, err, o, store_original_json_for_extras_and_extensions);
+  ParseExtrasAndExtensions(asset, err, o,
+                           store_original_json_for_extras_and_extensions);
   return true;
 }
 
 static bool ParseImage(Image *image, const int image_idx, std::string *err,
                        std::string *warn, const detail::json &o,
                        bool store_original_json_for_extras_and_extensions,
-                       const std::string &basedir, const size_t max_file_size, FsCallbacks *fs,
-                       const URICallbacks *uri_cb,
+                       const std::string &basedir, const size_t max_file_size,
+                       FsCallbacks *fs, const URICallbacks *uri_cb,
                        LoadImageDataFunction *LoadImageData = nullptr,
                        void *load_image_user_data = nullptr) {
   // A glTF image must either reference a bufferView or an image uri
@@ -4225,7 +4238,8 @@ static bool ParseImage(Image *image, const int image_idx, std::string *err,
     return false;
   }
 
-  ParseExtrasAndExtensions(image, err, o, store_original_json_for_extras_and_extensions);
+  ParseExtrasAndExtensions(image, err, o,
+                           store_original_json_for_extras_and_extensions);
 
   if (hasBufferView) {
     int bufferView = -1;
@@ -4301,7 +4315,8 @@ static bool ParseImage(Image *image, const int image_idx, std::string *err,
 
     if (!LoadExternalFile(&img, err, warn, decoded_uri, basedir,
                           /* required */ false, /* required bytes */ 0,
-                          /* checksize */ false, /* max file size */ max_file_size, fs)) {
+                          /* checksize */ false,
+                          /* max file size */ max_file_size, fs)) {
       if (warn) {
         (*warn) += "Failed to load external 'uri' for image[" +
                    std::to_string(image_idx) + "] name = \"" + decoded_uri +
@@ -4332,7 +4347,8 @@ static bool ParseImage(Image *image, const int image_idx, std::string *err,
                           static_cast<int>(img.size()), load_image_user_data);
 }
 
-static bool ParseTexture(Texture *texture, std::string *err, const detail::json &o,
+static bool ParseTexture(Texture *texture, std::string *err,
+                         const detail::json &o,
                          bool store_original_json_for_extras_and_extensions,
                          const std::string &basedir) {
   (void)basedir;
@@ -4345,7 +4361,8 @@ static bool ParseTexture(Texture *texture, std::string *err, const detail::json 
   texture->sampler = sampler;
   texture->source = source;
 
-  ParseExtrasAndExtensions(texture, err, o, store_original_json_for_extras_and_extensions);
+  ParseExtrasAndExtensions(texture, err, o,
+                           store_original_json_for_extras_and_extensions);
 
   ParseStringProperty(&texture->name, err, o, "name", false);
 
@@ -4366,7 +4383,8 @@ static bool ParseTextureInfo(
 
   ParseIntegerProperty(&texinfo->texCoord, err, o, "texCoord", false);
 
-  ParseExtrasAndExtensions(texinfo, err, o, store_original_json_for_extras_and_extensions);
+  ParseExtrasAndExtensions(texinfo, err, o,
+                           store_original_json_for_extras_and_extensions);
 
   return true;
 }
@@ -4386,7 +4404,8 @@ static bool ParseNormalTextureInfo(
   ParseIntegerProperty(&texinfo->texCoord, err, o, "texCoord", false);
   ParseNumberProperty(&texinfo->scale, err, o, "scale", false);
 
-  ParseExtrasAndExtensions(texinfo, err, o, store_original_json_for_extras_and_extensions);
+  ParseExtrasAndExtensions(texinfo, err, o,
+                           store_original_json_for_extras_and_extensions);
 
   return true;
 }
@@ -4406,7 +4425,8 @@ static bool ParseOcclusionTextureInfo(
   ParseIntegerProperty(&texinfo->texCoord, err, o, "texCoord", false);
   ParseNumberProperty(&texinfo->strength, err, o, "strength", false);
 
-  ParseExtrasAndExtensions(texinfo, err, o, store_original_json_for_extras_and_extensions);
+  ParseExtrasAndExtensions(texinfo, err, o,
+                           store_original_json_for_extras_and_extensions);
 
   return true;
 }
@@ -4414,7 +4434,8 @@ static bool ParseOcclusionTextureInfo(
 static bool ParseBuffer(Buffer *buffer, std::string *err, const detail::json &o,
                         bool store_original_json_for_extras_and_extensions,
                         FsCallbacks *fs, const URICallbacks *uri_cb,
-                        const std::string &basedir, const size_t max_buffer_size, bool is_binary = false,
+                        const std::string &basedir,
+                        const size_t max_buffer_size, bool is_binary = false,
                         const unsigned char *bin_data = nullptr,
                         size_t bin_size = 0) {
   size_t byteLength;
@@ -4466,7 +4487,8 @@ static bool ParseBuffer(Buffer *buffer, std::string *err, const detail::json &o,
         }
         if (!LoadExternalFile(&buffer->data, err, /* warn */ nullptr,
                               decoded_uri, basedir, /* required */ true,
-                              byteLength, /* checkSize */ true, /* max_file_size */max_buffer_size, fs)) {
+                              byteLength, /* checkSize */ true,
+                              /* max_file_size */ max_buffer_size, fs)) {
           return false;
         }
       }
@@ -4475,7 +4497,8 @@ static bool ParseBuffer(Buffer *buffer, std::string *err, const detail::json &o,
 
       if ((bin_size == 0) || (bin_data == nullptr)) {
         if (err) {
-          (*err) += "Invalid binary data in `Buffer', or GLB with empty BIN chunk.\n";
+          (*err) +=
+              "Invalid binary data in `Buffer', or GLB with empty BIN chunk.\n";
         }
         return false;
       }
@@ -4514,7 +4537,8 @@ static bool ParseBuffer(Buffer *buffer, std::string *err, const detail::json &o,
       }
       if (!LoadExternalFile(&buffer->data, err, /* warn */ nullptr, decoded_uri,
                             basedir, /* required */ true, byteLength,
-                            /* checkSize */ true, /* max file size */max_buffer_size, fs)) {
+                            /* checkSize */ true,
+                            /* max file size */ max_buffer_size, fs)) {
         return false;
       }
     }
@@ -4522,7 +4546,8 @@ static bool ParseBuffer(Buffer *buffer, std::string *err, const detail::json &o,
 
   ParseStringProperty(&buffer->name, err, o, "name", false);
 
-  ParseExtrasAndExtensions(buffer, err, o, store_original_json_for_extras_and_extensions);
+  ParseExtrasAndExtensions(buffer, err, o,
+                           store_original_json_for_extras_and_extensions);
 
   return true;
 }
@@ -4578,7 +4603,8 @@ static bool ParseBufferView(
 
   ParseStringProperty(&bufferView->name, err, o, "name", false);
 
-  ParseExtrasAndExtensions(bufferView, err, o, store_original_json_for_extras_and_extensions);
+  ParseExtrasAndExtensions(bufferView, err, o,
+                           store_original_json_for_extras_and_extensions);
 
   bufferView->buffer = buffer;
   bufferView->byteOffset = byteOffset;
@@ -4587,9 +4613,9 @@ static bool ParseBufferView(
   return true;
 }
 
-static bool ParseSparseAccessor(Accessor::Sparse *sparse, std::string *err,
-                                const detail::json &o,
-                                bool store_original_json_for_extras_and_extensions) {
+static bool ParseSparseAccessor(
+    Accessor::Sparse *sparse, std::string *err, const detail::json &o,
+    bool store_original_json_for_extras_and_extensions) {
   sparse->isSparse = true;
 
   int count = 0;
@@ -4597,7 +4623,8 @@ static bool ParseSparseAccessor(Accessor::Sparse *sparse, std::string *err,
     return false;
   }
 
-  ParseExtrasAndExtensions(sparse, err, o, store_original_json_for_extras_and_extensions);
+  ParseExtrasAndExtensions(sparse, err, o,
+                           store_original_json_for_extras_and_extensions);
 
   detail::json_const_iterator indices_iterator;
   detail::json_const_iterator values_iterator;
@@ -4639,17 +4666,18 @@ static bool ParseSparseAccessor(Accessor::Sparse *sparse, std::string *err,
   sparse->indices.byteOffset = indices_byte_offset;
   sparse->indices.componentType = component_type;
   ParseExtrasAndExtensions(&sparse->indices, err, indices_obj,
-      store_original_json_for_extras_and_extensions);
+                           store_original_json_for_extras_and_extensions);
 
   sparse->values.bufferView = values_buffer_view;
   sparse->values.byteOffset = values_byte_offset;
   ParseExtrasAndExtensions(&sparse->values, err, values_obj,
-      store_original_json_for_extras_and_extensions);
+                           store_original_json_for_extras_and_extensions);
 
   return true;
 }
 
-static bool ParseAccessor(Accessor *accessor, std::string *err, const detail::json &o,
+static bool ParseAccessor(Accessor *accessor, std::string *err,
+                          const detail::json &o,
                           bool store_original_json_for_extras_and_extensions) {
   int bufferView = -1;
   ParseIntegerProperty(&bufferView, err, o, "bufferView", false, "Accessor");
@@ -4729,14 +4757,16 @@ static bool ParseAccessor(Accessor *accessor, std::string *err, const detail::js
     }
   }
 
-  ParseExtrasAndExtensions(accessor, err, o, store_original_json_for_extras_and_extensions);
+  ParseExtrasAndExtensions(accessor, err, o,
+                           store_original_json_for_extras_and_extensions);
 
   // check if accessor has a "sparse" object:
   detail::json_const_iterator iterator;
   if (detail::FindMember(o, "sparse", iterator)) {
     // here this accessor has a "sparse" subobject
-    return ParseSparseAccessor(&accessor->sparse, err, detail::GetValue(iterator),
-        store_original_json_for_extras_and_extensions);
+    return ParseSparseAccessor(&accessor->sparse, err,
+                               detail::GetValue(iterator),
+                               store_original_json_for_extras_and_extensions);
   }
 
   return true;
@@ -4958,7 +4988,8 @@ static bool ParsePrimitive(Primitive *primitive, Model *model, std::string *err,
   if (detail::FindMember(o, "targets", targetsObject) &&
       detail::IsArray(detail::GetValue(targetsObject))) {
     auto targetsObjectEnd = detail::ArrayEnd(detail::GetValue(targetsObject));
-    for (detail::json_const_array_iterator i = detail::ArrayBegin(detail::GetValue(targetsObject));
+    for (detail::json_const_array_iterator i =
+             detail::ArrayBegin(detail::GetValue(targetsObject));
          i != targetsObjectEnd; ++i) {
       std::map<std::string, int> targetAttribues;
 
@@ -4977,7 +5008,8 @@ static bool ParsePrimitive(Primitive *primitive, Model *model, std::string *err,
     }
   }
 
-  ParseExtrasAndExtensions(primitive, err, o, store_original_json_for_extras_and_extensions);
+  ParseExtrasAndExtensions(primitive, err, o,
+                           store_original_json_for_extras_and_extensions);
 
 #ifdef TINYGLTF_ENABLE_DRACO
   auto dracoExtension =
@@ -4992,7 +5024,8 @@ static bool ParsePrimitive(Primitive *primitive, Model *model, std::string *err,
   return true;
 }
 
-static bool ParseMesh(Mesh *mesh, Model *model, std::string *err, const detail::json &o,
+static bool ParseMesh(Mesh *mesh, Model *model, std::string *err,
+                      const detail::json &o,
                       bool store_original_json_for_extras_and_extensions) {
   ParseStringProperty(&mesh->name, err, o, "name", false);
 
@@ -5000,8 +5033,10 @@ static bool ParseMesh(Mesh *mesh, Model *model, std::string *err, const detail::
   detail::json_const_iterator primObject;
   if (detail::FindMember(o, "primitives", primObject) &&
       detail::IsArray(detail::GetValue(primObject))) {
-    detail::json_const_array_iterator primEnd = detail::ArrayEnd(detail::GetValue(primObject));
-    for (detail::json_const_array_iterator i = detail::ArrayBegin(detail::GetValue(primObject));
+    detail::json_const_array_iterator primEnd =
+        detail::ArrayEnd(detail::GetValue(primObject));
+    for (detail::json_const_array_iterator i =
+             detail::ArrayBegin(detail::GetValue(primObject));
          i != primEnd; ++i) {
       Primitive primitive;
       if (ParsePrimitive(&primitive, model, err, *i,
@@ -5015,7 +5050,8 @@ static bool ParseMesh(Mesh *mesh, Model *model, std::string *err, const detail::
   // Should probably check if has targets and if dimensions fit
   ParseNumberArrayProperty(&mesh->weights, err, o, "weights", false);
 
-  ParseExtrasAndExtensions(mesh, err, o, store_original_json_for_extras_and_extensions);
+  ParseExtrasAndExtensions(mesh, err, o,
+                           store_original_json_for_extras_and_extensions);
 
   return true;
 }
@@ -5048,18 +5084,20 @@ static bool ParseNode(Node *node, std::string *err, const detail::json &o,
 
   ParseNumberArrayProperty(&node->weights, err, o, "weights", false);
 
-  ParseExtrasAndExtensions(node, err, o, store_original_json_for_extras_and_extensions);
+  ParseExtrasAndExtensions(node, err, o,
+                           store_original_json_for_extras_and_extensions);
 
   // KHR_lights_punctual: parse light source reference
   int light = -1;
   if (node->extensions.count("KHR_lights_punctual") != 0) {
-    auto const& light_ext = node->extensions["KHR_lights_punctual"];
+    auto const &light_ext = node->extensions["KHR_lights_punctual"];
     if (light_ext.Has("light")) {
       light = light_ext.Get("light").GetNumberAsInt();
     } else {
       if (err) {
-        *err += "Node has extension KHR_lights_punctual, but does not reference "
-          "a light source.\n";
+        *err +=
+            "Node has extension KHR_lights_punctual, but does not reference "
+            "a light source.\n";
       }
       return false;
     }
@@ -5148,7 +5186,8 @@ static bool ParsePbrMetallicRoughness(
   {
     detail::json_const_iterator it;
     if (detail::FindMember(o, "metallicRoughnessTexture", it)) {
-      ParseTextureInfo(&pbr->metallicRoughnessTexture, err, detail::GetValue(it),
+      ParseTextureInfo(&pbr->metallicRoughnessTexture, err,
+                       detail::GetValue(it),
                        store_original_json_for_extras_and_extensions);
     }
   }
@@ -5156,12 +5195,14 @@ static bool ParsePbrMetallicRoughness(
   ParseNumberProperty(&pbr->metallicFactor, err, o, "metallicFactor", false);
   ParseNumberProperty(&pbr->roughnessFactor, err, o, "roughnessFactor", false);
 
-  ParseExtrasAndExtensions(pbr, err, o, store_original_json_for_extras_and_extensions);
+  ParseExtrasAndExtensions(pbr, err, o,
+                           store_original_json_for_extras_and_extensions);
 
   return true;
 }
 
-static bool ParseMaterial(Material *material, std::string *err, const detail::json &o,
+static bool ParseMaterial(Material *material, std::string *err,
+                          const detail::json &o,
                           bool store_original_json_for_extras_and_extensions) {
   ParseStringProperty(&material->name, err, o, "name", /* required */ false);
 
@@ -5201,7 +5242,8 @@ static bool ParseMaterial(Material *material, std::string *err, const detail::js
   {
     detail::json_const_iterator it;
     if (detail::FindMember(o, "normalTexture", it)) {
-      ParseNormalTextureInfo(&material->normalTexture, err, detail::GetValue(it),
+      ParseNormalTextureInfo(&material->normalTexture, err,
+                             detail::GetValue(it),
                              store_original_json_for_extras_and_extensions);
     }
   }
@@ -5209,7 +5251,8 @@ static bool ParseMaterial(Material *material, std::string *err, const detail::js
   {
     detail::json_const_iterator it;
     if (detail::FindMember(o, "occlusionTexture", it)) {
-      ParseOcclusionTextureInfo(&material->occlusionTexture, err, detail::GetValue(it),
+      ParseOcclusionTextureInfo(&material->occlusionTexture, err,
+                                detail::GetValue(it),
                                 store_original_json_for_extras_and_extensions);
     }
   }
@@ -5244,8 +5287,8 @@ static bool ParseMaterial(Material *material, std::string *err, const detail::js
 
         for (; itVal != itValEnd; ++itVal) {
           Parameter param;
-          if (ParseParameterProperty(&param, err, values_object, detail::GetKey(itVal),
-                                     false)) {
+          if (ParseParameterProperty(&param, err, values_object,
+                                     detail::GetKey(itVal), false)) {
             material->values.emplace(detail::GetKey(itVal), std::move(param));
           }
         }
@@ -5264,8 +5307,9 @@ static bool ParseMaterial(Material *material, std::string *err, const detail::js
     }
   }
 
-  material->extensions.clear(); // Note(agnat): Why?
-  ParseExtrasAndExtensions(material, err, o, store_original_json_for_extras_and_extensions);
+  material->extensions.clear();  // Note(agnat): Why?
+  ParseExtrasAndExtensions(material, err, o,
+                           store_original_json_for_extras_and_extensions);
 
   return true;
 }
@@ -5284,7 +5328,8 @@ static bool ParseAnimationChannel(
   }
 
   detail::json_const_iterator targetIt;
-  if (detail::FindMember(o, "target", targetIt) && detail::IsObject(detail::GetValue(targetIt))) {
+  if (detail::FindMember(o, "target", targetIt) &&
+      detail::IsObject(detail::GetValue(targetIt))) {
     const detail::json &target_object = detail::GetValue(targetIt);
 
     ParseIntegerProperty(&targetIndex, err, target_object, "node", false);
@@ -5302,13 +5347,15 @@ static bool ParseAnimationChannel(
       {
         detail::json_const_iterator it;
         if (detail::FindMember(target_object, "extensions", it)) {
-          channel->target_extensions_json_string = detail::JsonToString(detail::GetValue(it));
+          channel->target_extensions_json_string =
+              detail::JsonToString(detail::GetValue(it));
         }
       }
       {
         detail::json_const_iterator it;
         if (detail::FindMember(target_object, "extras", it)) {
-          channel->target_extras_json_string = detail::JsonToString(detail::GetValue(it));
+          channel->target_extras_json_string =
+              detail::JsonToString(detail::GetValue(it));
         }
       }
     }
@@ -5317,7 +5364,8 @@ static bool ParseAnimationChannel(
   channel->sampler = samplerIndex;
   channel->target_node = targetIndex;
 
-  ParseExtrasAndExtensions(channel, err, o, store_original_json_for_extras_and_extensions);
+  ParseExtrasAndExtensions(channel, err, o,
+                           store_original_json_for_extras_and_extensions);
 
   return true;
 }
@@ -5329,8 +5377,10 @@ static bool ParseAnimation(Animation *animation, std::string *err,
     detail::json_const_iterator channelsIt;
     if (detail::FindMember(o, "channels", channelsIt) &&
         detail::IsArray(detail::GetValue(channelsIt))) {
-      detail::json_const_array_iterator channelEnd = detail::ArrayEnd(detail::GetValue(channelsIt));
-      for (detail::json_const_array_iterator i = detail::ArrayBegin(detail::GetValue(channelsIt));
+      detail::json_const_array_iterator channelEnd =
+          detail::ArrayEnd(detail::GetValue(channelsIt));
+      for (detail::json_const_array_iterator i =
+               detail::ArrayBegin(detail::GetValue(channelsIt));
            i != channelEnd; ++i) {
         AnimationChannel channel;
         if (ParseAnimationChannel(
@@ -5345,7 +5395,8 @@ static bool ParseAnimation(Animation *animation, std::string *err,
 
   {
     detail::json_const_iterator samplerIt;
-    if (detail::FindMember(o, "samplers", samplerIt) && detail::IsArray(detail::GetValue(samplerIt))) {
+    if (detail::FindMember(o, "samplers", samplerIt) &&
+        detail::IsArray(detail::GetValue(samplerIt))) {
       const detail::json &sampler_array = detail::GetValue(samplerIt);
 
       detail::json_const_array_iterator it = detail::ArrayBegin(sampler_array);
@@ -5374,7 +5425,7 @@ static bool ParseAnimation(Animation *animation, std::string *err,
         sampler.input = inputIndex;
         sampler.output = outputIndex;
         ParseExtrasAndExtensions(&sampler, err, o,
-            store_original_json_for_extras_and_extensions);
+                                 store_original_json_for_extras_and_extensions);
 
         animation->samplers.emplace_back(std::move(sampler));
       }
@@ -5383,12 +5434,14 @@ static bool ParseAnimation(Animation *animation, std::string *err,
 
   ParseStringProperty(&animation->name, err, o, "name", false);
 
-  ParseExtrasAndExtensions(animation, err, o, store_original_json_for_extras_and_extensions);
+  ParseExtrasAndExtensions(animation, err, o,
+                           store_original_json_for_extras_and_extensions);
 
   return true;
 }
 
-static bool ParseSampler(Sampler *sampler, std::string *err, const detail::json &o,
+static bool ParseSampler(Sampler *sampler, std::string *err,
+                         const detail::json &o,
                          bool store_original_json_for_extras_and_extensions) {
   ParseStringProperty(&sampler->name, err, o, "name", false);
 
@@ -5413,7 +5466,8 @@ static bool ParseSampler(Sampler *sampler, std::string *err, const detail::json 
   sampler->wrapT = wrapT;
   // sampler->wrapR = wrapR;
 
-  ParseExtrasAndExtensions(sampler, err, o, store_original_json_for_extras_and_extensions);
+  ParseExtrasAndExtensions(sampler, err, o,
+                           store_original_json_for_extras_and_extensions);
 
   return true;
 }
@@ -5436,7 +5490,8 @@ static bool ParseSkin(Skin *skin, std::string *err, const detail::json &o,
   ParseIntegerProperty(&invBind, err, o, "inverseBindMatrices", true, "Skin");
   skin->inverseBindMatrices = invBind;
 
-  ParseExtrasAndExtensions(skin, err, o, store_original_json_for_extras_and_extensions);
+  ParseExtrasAndExtensions(skin, err, o,
+                           store_original_json_for_extras_and_extensions);
 
   return true;
 }
@@ -5467,19 +5522,22 @@ static bool ParsePerspectiveCamera(
   camera->yfov = yfov;
   camera->znear = znear;
 
-  ParseExtrasAndExtensions(camera, err, o, store_original_json_for_extras_and_extensions);
+  ParseExtrasAndExtensions(camera, err, o,
+                           store_original_json_for_extras_and_extensions);
 
   // TODO(syoyo): Validate parameter values.
 
   return true;
 }
 
-static bool ParseSpotLight(SpotLight *light, std::string *err, const detail::json &o,
+static bool ParseSpotLight(SpotLight *light, std::string *err,
+                           const detail::json &o,
                            bool store_original_json_for_extras_and_extensions) {
   ParseNumberProperty(&light->innerConeAngle, err, o, "innerConeAngle", false);
   ParseNumberProperty(&light->outerConeAngle, err, o, "outerConeAngle", false);
 
-  ParseExtrasAndExtensions(light, err, o, store_original_json_for_extras_and_extensions);
+  ParseExtrasAndExtensions(light, err, o,
+                           store_original_json_for_extras_and_extensions);
 
   // TODO(syoyo): Validate parameter values.
 
@@ -5510,7 +5568,8 @@ static bool ParseOrthographicCamera(
     return false;
   }
 
-  ParseExtrasAndExtensions(camera, err, o, store_original_json_for_extras_and_extensions);
+  ParseExtrasAndExtensions(camera, err, o,
+                           store_original_json_for_extras_and_extensions);
 
   camera->xmag = xmag;
   camera->ymag = ymag;
@@ -5592,7 +5651,8 @@ static bool ParseCamera(Camera *camera, std::string *err, const detail::json &o,
 
   ParseStringProperty(&camera->name, err, o, "name", false);
 
-  ParseExtrasAndExtensions(camera, err, o, store_original_json_for_extras_and_extensions);
+  ParseExtrasAndExtensions(camera, err, o,
+                           store_original_json_for_extras_and_extensions);
 
   return true;
 }
@@ -5635,7 +5695,8 @@ static bool ParseLight(Light *light, std::string *err, const detail::json &o,
   ParseNumberProperty(&light->range, err, o, "range", false);
   ParseNumberProperty(&light->intensity, err, o, "intensity", false);
 
-  ParseExtrasAndExtensions(light, err, o, store_original_json_for_extras_and_extensions);
+  ParseExtrasAndExtensions(light, err, o,
+                           store_original_json_for_extras_and_extensions);
 
   return true;
 }
@@ -5643,14 +5704,19 @@ static bool ParseLight(Light *light, std::string *err, const detail::json &o,
 static bool ParsePositionalEmitter(
     PositionalEmitter *positional, std::string *err, const detail::json &o,
     bool store_original_json_for_extras_and_extensions) {
-  ParseNumberProperty(&positional->coneInnerAngle, err, o, "coneInnerAngle", false);
-  ParseNumberProperty(&positional->coneOuterAngle, err, o, "coneOuterAngle", false);
-  ParseNumberProperty(&positional->coneOuterGain, err, o, "coneOuterGain", false);
+  ParseNumberProperty(&positional->coneInnerAngle, err, o, "coneInnerAngle",
+                      false);
+  ParseNumberProperty(&positional->coneOuterAngle, err, o, "coneOuterAngle",
+                      false);
+  ParseNumberProperty(&positional->coneOuterGain, err, o, "coneOuterGain",
+                      false);
   ParseNumberProperty(&positional->maxDistance, err, o, "maxDistance", false);
   ParseNumberProperty(&positional->refDistance, err, o, "refDistance", false);
-  ParseNumberProperty(&positional->rolloffFactor, err, o, "rolloffFactor", false);
+  ParseNumberProperty(&positional->rolloffFactor, err, o, "rolloffFactor",
+                      false);
 
-  ParseExtrasAndExtensions(positional, err, o, store_original_json_for_extras_and_extensions);
+  ParseExtrasAndExtensions(positional, err, o,
+                           store_original_json_for_extras_and_extensions);
 
   return true;
 }
@@ -5683,8 +5749,9 @@ static bool ParseAudioEmitter(
       return false;
     }
 
-    if (!ParsePositionalEmitter(&emitter->positional, err, v,
-                        store_original_json_for_extras_and_extensions)) {
+    if (!ParsePositionalEmitter(
+            &emitter->positional, err, v,
+            store_original_json_for_extras_and_extensions)) {
       return false;
     }
   }
@@ -5722,9 +5789,10 @@ static bool ParseAudioSource(
 namespace detail {
 
 template <typename Callback>
-bool ForEachInArray(const detail::json &_v, const char *member, Callback && cb) {
+bool ForEachInArray(const detail::json &_v, const char *member, Callback &&cb) {
   detail::json_const_iterator itm;
-  if (detail::FindMember(_v, member, itm) && detail::IsArray(detail::GetValue(itm))) {
+  if (detail::FindMember(_v, member, itm) &&
+      detail::IsArray(detail::GetValue(itm))) {
     const detail::json &root = detail::GetValue(itm);
     auto it = detail::ArrayBegin(root);
     auto end = detail::ArrayEnd(root);
@@ -5735,7 +5803,7 @@ bool ForEachInArray(const detail::json &_v, const char *member, Callback && cb) 
   return true;
 };
 
-} // end of namespace detail
+}  // end of namespace detail
 
 bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
                               const char *json_str,
@@ -5788,7 +5856,8 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
   {
     bool version_found = false;
     detail::json_const_iterator it;
-    if (detail::FindMember(v, "asset", it) && detail::IsObject(detail::GetValue(it))) {
+    if (detail::FindMember(v, "asset", it) &&
+        detail::IsObject(detail::GetValue(it))) {
       auto &itObj = detail::GetValue(it);
       detail::json_const_iterator version_it;
       std::string versionStr;
@@ -5810,9 +5879,11 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
   // scene is not mandatory.
   // FIXME Maybe a better way to handle it than removing the code
 
-  auto IsArrayMemberPresent = [](const detail::json &_v, const char *name) -> bool {
+  auto IsArrayMemberPresent = [](const detail::json &_v,
+                                 const char *name) -> bool {
     detail::json_const_iterator it;
-    return detail::FindMember(_v, name, it) && detail::IsArray(detail::GetValue(it));
+    return detail::FindMember(_v, name, it) &&
+           detail::IsArray(detail::GetValue(it));
   };
 
   {
@@ -5878,7 +5949,8 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
   // 1. Parse Asset
   {
     detail::json_const_iterator it;
-    if (detail::FindMember(v, "asset", it) && detail::IsObject(detail::GetValue(it))) {
+    if (detail::FindMember(v, "asset", it) &&
+        detail::IsObject(detail::GetValue(it))) {
       const detail::json &root = detail::GetValue(it);
 
       ParseAsset(&model->asset, err, root,
@@ -5919,7 +5991,8 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
       Buffer buffer;
       if (!ParseBuffer(&buffer, err, o,
                        store_original_json_for_extras_and_extensions_, &fs,
-                       &uri_cb, base_dir, max_external_file_size_, is_binary_, bin_data_, bin_size_)) {
+                       &uri_cb, base_dir, max_external_file_size_, is_binary_,
+                       bin_data_, bin_size_)) {
         return false;
       }
 
@@ -6052,7 +6125,8 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
           if (accessorsIndex < model->accessors.size()) {
             const auto bufferView = model->accessors[accessorsIndex].bufferView;
             // bufferView could be null(-1) for sparse morph target
-            if (bufferView >= 0 && bufferView < (int)model->bufferViews.size()) {
+            if (bufferView >= 0 &&
+                bufferView < (int)model->bufferViews.size()) {
               model->bufferViews[size_t(bufferView)].target =
                   TINYGLTF_TARGET_ARRAY_BUFFER;
             }
@@ -6115,7 +6189,8 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
   {
     detail::json_const_iterator rootIt;
     int iVal;
-    if (detail::FindMember(v, "scene", rootIt) && detail::GetInt(detail::GetValue(rootIt), iVal)) {
+    if (detail::FindMember(v, "scene", rootIt) &&
+        detail::GetInt(detail::GetValue(rootIt), iVal)) {
       model->defaultScene = iVal;
     }
   }
@@ -6171,8 +6246,8 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
       Image image;
       if (!ParseImage(&image, idx, err, warn, o,
                       store_original_json_for_extras_and_extensions_, base_dir,
-                      max_external_file_size_, &fs, &uri_cb, &this->LoadImageData,
-                      load_image_user_data)) {
+                      max_external_file_size_, &fs, &uri_cb,
+                      &this->LoadImageData, load_image_user_data)) {
         return false;
       }
 
@@ -6348,12 +6423,14 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
   }
 
   // 17. Parse Extras & Extensions
-  ParseExtrasAndExtensions(model, err, v, store_original_json_for_extras_and_extensions_);
+  ParseExtrasAndExtensions(model, err, v,
+                           store_original_json_for_extras_and_extensions_);
 
   // 18. Specific extension implementations
   {
     detail::json_const_iterator rootIt;
-    if (detail::FindMember(v, "extensions", rootIt) && detail::IsObject(detail::GetValue(rootIt))) {
+    if (detail::FindMember(v, "extensions", rootIt) &&
+        detail::IsObject(detail::GetValue(rootIt))) {
       const detail::json &root = detail::GetValue(rootIt);
 
       detail::json_const_iterator it(detail::ObjectBegin(root));
@@ -6361,7 +6438,8 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
       for (; it != itEnd; ++it) {
         // parse KHR_lights_punctual extension
         std::string key(detail::GetKey(it));
-        if ((key == "KHR_lights_punctual") && detail::IsObject(detail::GetValue(it))) {
+        if ((key == "KHR_lights_punctual") &&
+            detail::IsObject(detail::GetValue(it))) {
           const detail::json &object = detail::GetValue(it);
           detail::json_const_iterator itLight;
           if (detail::FindMember(object, "lights", itLight)) {
@@ -6383,8 +6461,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
           }
         }
         // parse KHR_audio extension
-        if ((key == "KHR_audio") &&
-                   detail::IsObject(detail::GetValue(it))) {
+        if ((key == "KHR_audio") && detail::IsObject(detail::GetValue(it))) {
           const detail::json &object = detail::GetValue(it);
           detail::json_const_iterator itKhrAudio;
           if (detail::FindMember(object, "emitters", itKhrAudio)) {
@@ -6397,8 +6474,9 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
             auto arrayItEnd(detail::ArrayEnd(emitters));
             for (; arrayIt != arrayItEnd; ++arrayIt) {
               AudioEmitter emitter;
-              if (!ParseAudioEmitter(&emitter, err, *arrayIt,
-                              store_original_json_for_extras_and_extensions_)) {
+              if (!ParseAudioEmitter(
+                      &emitter, err, *arrayIt,
+                      store_original_json_for_extras_and_extensions_)) {
                 return false;
               }
               model->audioEmitters.emplace_back(std::move(emitter));
@@ -6510,8 +6588,8 @@ bool TinyGLTF::LoadBinaryFromMemory(Model *model, std::string *err,
     return false;
   }
 
-  unsigned int version;       // 4 bytes
-  unsigned int length;        // 4 bytes
+  unsigned int version;        // 4 bytes
+  unsigned int length;         // 4 bytes
   unsigned int chunk0_length;  // 4 bytes
   unsigned int chunk0_format;  // 4 bytes;
 
@@ -6519,7 +6597,7 @@ bool TinyGLTF::LoadBinaryFromMemory(Model *model, std::string *err,
   swap4(&version);
   memcpy(&length, bytes + 8, 4);
   swap4(&length);
-  memcpy(&chunk0_length, bytes + 12, 4); // JSON data length
+  memcpy(&chunk0_length, bytes + 12, 4);  // JSON data length
   swap4(&chunk0_length);
   memcpy(&chunk0_format, bytes + 16, 4);
   swap4(&chunk0_format);
@@ -6536,11 +6614,11 @@ bool TinyGLTF::LoadBinaryFromMemory(Model *model, std::string *err,
 
   if (header_and_json_size > std::numeric_limits<uint32_t>::max()) {
     // Do not allow 4GB or more GLB data.
-   (*err) = "Invalid glTF binary. GLB data exceeds 4GB.";
+    (*err) = "Invalid glTF binary. GLB data exceeds 4GB.";
   }
 
-  if ((header_and_json_size > uint64_t(size)) || (chunk0_length < 1) || (length > size) ||
-      (header_and_json_size > uint64_t(length)) ||
+  if ((header_and_json_size > uint64_t(size)) || (chunk0_length < 1) ||
+      (length > size) || (header_and_json_size > uint64_t(length)) ||
       (chunk0_format != 0x4E4F534A)) {  // 0x4E4F534A = JSON format.
     if (err) {
       (*err) = "Invalid glTF binary.";
@@ -6557,34 +6635,40 @@ bool TinyGLTF::LoadBinaryFromMemory(Model *model, std::string *err,
     }
   }
 
-  //std::cout << "header_and_json_size = " << header_and_json_size << "\n";
-  //std::cout << "length = " << length << "\n";
+  // std::cout << "header_and_json_size = " << header_and_json_size << "\n";
+  // std::cout << "length = " << length << "\n";
 
   // Chunk1(BIN) data
-  // The spec says: When the binary buffer is empty or when it is stored by other means, this chunk SHOULD be omitted.
-  // So when header + JSON data == binary size, Chunk1 is omitted.
+  // The spec says: When the binary buffer is empty or when it is stored by
+  // other means, this chunk SHOULD be omitted. So when header + JSON data ==
+  // binary size, Chunk1 is omitted.
   if (header_and_json_size == uint64_t(length)) {
-
     bin_data_ = nullptr;
     bin_size_ = 0;
   } else {
     // Read Chunk1 info(BIN data)
-    // At least Chunk1 should have 12 bytes(8 bytes(header) + 4 bytes(bin payload could be 1~3 bytes, but need to be aligned to 4 bytes)
+    // At least Chunk1 should have 12 bytes(8 bytes(header) + 4 bytes(bin
+    // payload could be 1~3 bytes, but need to be aligned to 4 bytes)
     if ((header_and_json_size + 12ull) > uint64_t(length)) {
       if (err) {
-        (*err) = "Insufficient storage space for Chunk1(BIN data). At least Chunk1 Must have 4 bytes or more bytes, but got " + std::to_string((header_and_json_size + 12ull) - uint64_t(length)) + ".\n";
+        (*err) =
+            "Insufficient storage space for Chunk1(BIN data). At least Chunk1 "
+            "Must have 4 bytes or more bytes, but got " +
+            std::to_string((header_and_json_size + 12ull) - uint64_t(length)) +
+            ".\n";
       }
       return false;
     }
 
     unsigned int chunk1_length;  // 4 bytes
     unsigned int chunk1_format;  // 4 bytes;
-    memcpy(&chunk1_length, bytes + header_and_json_size, 4); // JSON data length
+    memcpy(&chunk1_length, bytes + header_and_json_size,
+           4);  // JSON data length
     swap4(&chunk1_length);
     memcpy(&chunk1_format, bytes + header_and_json_size + 4, 4);
     swap4(&chunk1_format);
 
-    //std::cout << "chunk1_length = " << chunk1_length << "\n";
+    // std::cout << "chunk1_length = " << chunk1_length << "\n";
 
     if (chunk1_length < 4) {
       if (err) {
@@ -6614,7 +6698,7 @@ bool TinyGLTF::LoadBinaryFromMemory(Model *model, std::string *err,
       return false;
     }
 
-    //std::cout << "chunk1_length = " << chunk1_length << "\n";
+    // std::cout << "chunk1_length = " << chunk1_length << "\n";
 
     bin_data_ = bytes + header_and_json_size +
                 8;  // 4 bytes (bin_buffer_length) + 4 bytes(bin_buffer_format)
@@ -6701,13 +6785,15 @@ void JsonAddMember(detail::json &o, const char *key, detail::json &&value) {
   }
 
   // Issue 420.
-  // AddMember may create duplicated key, so use [] API when a key already exists.
+  // AddMember may create duplicated key, so use [] API when a key already
+  // exists.
   // https://github.com/Tencent/rapidjson/issues/771#issuecomment-254386863
   detail::json_const_iterator it;
   if (detail::FindMember(o, key, it)) {
-    o[key] = std::move(value); // replace
+    o[key] = std::move(value);  // replace
   } else {
-    o.AddMember(detail::json(key, detail::GetAllocator()), std::move(value), detail::GetAllocator());
+    o.AddMember(detail::json(key, detail::GetAllocator()), std::move(value),
+                detail::GetAllocator());
   }
 #else
   o[key] = std::move(value);
@@ -6746,7 +6832,7 @@ void JsonReserveArray(detail::json &o, size_t s) {
   (void)(o);
   (void)(s);
 }
-}  // namespace
+}  // namespace detail
 
 // typedef std::pair<std::string, detail::json> json_object_pair;
 
@@ -6761,8 +6847,10 @@ static void SerializeNumberProperty(const std::string &key, T number,
 
 #ifdef TINYGLTF_USE_RAPIDJSON
 template <>
-void SerializeNumberProperty(const std::string &key, size_t number, detail::json &obj) {
-  detail::JsonAddMember(obj, key.c_str(), detail::json(static_cast<uint64_t>(number)));
+void SerializeNumberProperty(const std::string &key, size_t number,
+                             detail::json &obj) {
+  detail::JsonAddMember(obj, key.c_str(),
+                        detail::json(static_cast<uint64_t>(number)));
 }
 #endif
 
@@ -6781,8 +6869,10 @@ static void SerializeNumberArrayProperty(const std::string &key,
 }
 
 static void SerializeStringProperty(const std::string &key,
-                                    const std::string &value, detail::json &obj) {
-  detail::JsonAddMember(obj, key.c_str(), detail::JsonFromString(value.c_str()));
+                                    const std::string &value,
+                                    detail::json &obj) {
+  detail::JsonAddMember(obj, key.c_str(),
+                        detail::JsonFromString(value.c_str()));
 }
 
 static void SerializeStringArrayProperty(const std::string &key,
@@ -6975,7 +7065,8 @@ static void SerializeParameterMap(ParameterMap &param, detail::json &o) {
 }
 #endif
 
-static void SerializeExtensionMap(const ExtensionMap &extensions, detail::json &o) {
+static void SerializeExtensionMap(const ExtensionMap &extensions,
+                                  detail::json &o) {
   if (!extensions.size()) return;
 
   detail::json extMap;
@@ -7001,13 +7092,12 @@ static void SerializeExtensionMap(const ExtensionMap &extensions, detail::json &
   detail::JsonAddMember(o, "extensions", std::move(extMap));
 }
 
-static void SerializeExtras(const Value & extras, detail::json & o) {
-  if (extras.Type() != NULL_TYPE)
-    SerializeValue("extras", extras, o);
+static void SerializeExtras(const Value &extras, detail::json &o) {
+  if (extras.Type() != NULL_TYPE) SerializeValue("extras", extras, o);
 }
 
 template <typename GltfType>
-void SerializeExtrasAndExtensions(const GltfType & obj, detail::json & o) {
+void SerializeExtrasAndExtensions(const GltfType &obj, detail::json &o) {
   SerializeExtensionMap(obj.extensions, o);
   SerializeExtras(obj.extras, o);
 }
@@ -7081,27 +7171,31 @@ static void SerializeGltfAccessor(const Accessor &accessor, detail::json &o) {
   SerializeExtrasAndExtensions(accessor, o);
 
   // sparse
-  if (accessor.sparse.isSparse)
-  {
-      detail::json sparse;
-      SerializeNumberProperty<int>("count", accessor.sparse.count, sparse);
-      {
-          detail::json indices;
-          SerializeNumberProperty<int>("bufferView", accessor.sparse.indices.bufferView, indices);
-          SerializeNumberProperty<int>("byteOffset", accessor.sparse.indices.byteOffset, indices);
-          SerializeNumberProperty<int>("componentType", accessor.sparse.indices.componentType, indices);
-          SerializeExtrasAndExtensions(accessor.sparse.indices, indices);
-          detail::JsonAddMember(sparse, "indices", std::move(indices));
-      }
-      {
-          detail::json values;
-          SerializeNumberProperty<int>("bufferView", accessor.sparse.values.bufferView, values);
-          SerializeNumberProperty<int>("byteOffset", accessor.sparse.values.byteOffset, values);
-          SerializeExtrasAndExtensions(accessor.sparse.values, values);
-          detail::JsonAddMember(sparse, "values", std::move(values));
-      }
-      SerializeExtrasAndExtensions(accessor.sparse, sparse);
-      detail::JsonAddMember(o, "sparse", std::move(sparse));
+  if (accessor.sparse.isSparse) {
+    detail::json sparse;
+    SerializeNumberProperty<int>("count", accessor.sparse.count, sparse);
+    {
+      detail::json indices;
+      SerializeNumberProperty<int>("bufferView",
+                                   accessor.sparse.indices.bufferView, indices);
+      SerializeNumberProperty<int>("byteOffset",
+                                   accessor.sparse.indices.byteOffset, indices);
+      SerializeNumberProperty<int>(
+          "componentType", accessor.sparse.indices.componentType, indices);
+      SerializeExtrasAndExtensions(accessor.sparse.indices, indices);
+      detail::JsonAddMember(sparse, "indices", std::move(indices));
+    }
+    {
+      detail::json values;
+      SerializeNumberProperty<int>("bufferView",
+                                   accessor.sparse.values.bufferView, values);
+      SerializeNumberProperty<int>("byteOffset",
+                                   accessor.sparse.values.byteOffset, values);
+      SerializeExtrasAndExtensions(accessor.sparse.values, values);
+      detail::JsonAddMember(sparse, "values", std::move(values));
+    }
+    SerializeExtrasAndExtensions(accessor.sparse, sparse);
+    detail::JsonAddMember(o, "sparse", std::move(sparse));
   }
 }
 
@@ -7135,7 +7229,8 @@ static void SerializeGltfAnimationSampler(const AnimationSampler &sampler,
   SerializeExtrasAndExtensions(sampler, o);
 }
 
-static void SerializeGltfAnimation(const Animation &animation, detail::json &o) {
+static void SerializeGltfAnimation(const Animation &animation,
+                                   detail::json &o) {
   if (!animation.name.empty())
     SerializeStringProperty("name", animation.name, o);
 
@@ -7221,7 +7316,8 @@ static bool SerializeGltfBuffer(const Buffer &buffer, detail::json &o,
   return true;
 }
 
-static void SerializeGltfBufferView(const BufferView &bufferView, detail::json &o) {
+static void SerializeGltfBufferView(const BufferView &bufferView,
+                                    detail::json &o) {
   SerializeNumberProperty("buffer", bufferView.buffer, o);
   SerializeNumberProperty<size_t>("byteLength", bufferView.byteLength, o);
 
@@ -7263,7 +7359,8 @@ static void SerializeGltfImage(const Image &image, const std::string &uri,
   SerializeExtrasAndExtensions(image, o);
 }
 
-static void SerializeGltfTextureInfo(const TextureInfo &texinfo, detail::json &o) {
+static void SerializeGltfTextureInfo(const TextureInfo &texinfo,
+                                     detail::json &o) {
   SerializeNumberProperty("index", texinfo.index, o);
 
   if (texinfo.texCoord != 0) {
@@ -7387,7 +7484,8 @@ static void SerializeGltfMaterial(const Material &material, detail::json &o) {
     // importers (and validators).
     //
     if (!detail::JsonIsNull(pbrMetallicRoughness)) {
-      detail::JsonAddMember(o, "pbrMetallicRoughness", std::move(pbrMetallicRoughness));
+      detail::JsonAddMember(o, "pbrMetallicRoughness",
+                            std::move(pbrMetallicRoughness));
     }
   }
 
@@ -7527,7 +7625,8 @@ static void SerializeGltfAudioEmitter(const AudioEmitter &emitter,
   SerializeExtrasAndExtensions(emitter, o);
 }
 
-static void SerializeGltfAudioSource(const AudioSource& source, detail::json& o) {
+static void SerializeGltfAudioSource(const AudioSource &source,
+                                     detail::json &o) {
   std::string name;
   std::string uri;
   int bufferView;        // (required if no uri)
@@ -7538,9 +7637,8 @@ static void SerializeGltfAudioSource(const AudioSource& source, detail::json& o)
   if (source.uri.empty()) {
     SerializeStringProperty("mimeType", source.mimeType, o);
     SerializeNumberProperty<int>("bufferView", source.bufferView, o);
-  }
-  else {
-      SerializeStringProperty("uri", source.uri, o);
+  } else {
+    SerializeStringProperty("uri", source.uri, o);
   }
   SerializeExtrasAndExtensions(source, o);
 }
@@ -7589,11 +7687,12 @@ static void SerializeGltfNode(const Node &node, detail::json &o) {
       detail::JsonAddMember(o, "extensions", std::move(extensions));
       detail::FindMember(o, "extensions", it);
     }
-    auto & extensions = detail::GetValue(it);
-    if ( ! detail::FindMember(extensions, "KHR_lights_punctual", it)) {
+    auto &extensions = detail::GetValue(it);
+    if (!detail::FindMember(extensions, "KHR_lights_punctual", it)) {
       detail::json lights_punctual;
       detail::JsonSetObject(lights_punctual);
-      detail::JsonAddMember(extensions, "KHR_lights_punctual", std::move(lights_punctual));
+      detail::JsonAddMember(extensions, "KHR_lights_punctual",
+                            std::move(lights_punctual));
       detail::FindMember(o, "KHR_lights_punctual", it);
     }
     SerializeNumberProperty("light", node.light, detail::GetValue(it));
@@ -7601,7 +7700,7 @@ static void SerializeGltfNode(const Node &node, detail::json &o) {
     // node has no light ref (any longer)... so we clean up
     detail::json_iterator ext_it;
     if (detail::FindMember(o, "extensions", ext_it)) {
-      auto & extensions = detail::GetValue(ext_it);
+      auto &extensions = detail::GetValue(ext_it);
       detail::json_iterator lp_it;
       if (detail::FindMember(extensions, "KHR_lights_punctual", lp_it)) {
         detail::Erase(extensions, lp_it);
@@ -7734,7 +7833,8 @@ static void SerializeGltfScene(const Scene &scene, detail::json &o) {
       detail::JsonAddMember(extensions, "KHR_audio", std::move(audio));
       detail::FindMember(o, "KHR_audio", it);
     }
-    SerializeNumberArrayProperty("emitters", scene.audioEmitters, detail::GetValue(it));
+    SerializeNumberArrayProperty("emitters", scene.audioEmitters,
+                                 detail::GetValue(it));
   } else {
     detail::json_iterator ext_it;
     if (detail::FindMember(o, "extensions", ext_it)) {
@@ -7972,7 +8072,8 @@ static void SerializeGltfModel(const Model *model, detail::json &o) {
       }
     }
 
-    detail::JsonAddMember(ext_j, "KHR_lights_punctual", std::move(khr_lights_cmn));
+    detail::JsonAddMember(ext_j, "KHR_lights_punctual",
+                          std::move(khr_lights_cmn));
 
     detail::JsonAddMember(o, "extensions", std::move(ext_j));
 
@@ -8025,11 +8126,9 @@ static void SerializeGltfModel(const Model *model, detail::json &o) {
 
     // Also add "KHR_audio" to `extensionsUsed`
     {
-      auto has_khr_audio =
-          std::find_if(extensionsUsed.begin(), extensionsUsed.end(),
-                       [](const std::string &s) {
-                         return (s.compare("KHR_audio") == 0);
-                       });
+      auto has_khr_audio = std::find_if(
+          extensionsUsed.begin(), extensionsUsed.end(),
+          [](const std::string &s) { return (s.compare("KHR_audio") == 0); });
 
       if (has_khr_audio == extensionsUsed.end()) {
         extensionsUsed.push_back("KHR_audio");
@@ -8202,9 +8301,11 @@ bool TinyGLTF::WriteGltfSceneToStream(const Model *model, std::ostream &stream,
   }
 
   if (writeBinary) {
-    return WriteBinaryGltfStream(stream, detail::JsonToString(output), binBuffer);
+    return WriteBinaryGltfStream(stream, detail::JsonToString(output),
+                                 binBuffer);
   } else {
-    return WriteGltfStream(stream, detail::JsonToString(output, prettyPrint ? 2 : -1));
+    return WriteGltfStream(stream,
+                           detail::JsonToString(output, prettyPrint ? 2 : -1));
   }
 }
 
@@ -8308,9 +8409,11 @@ bool TinyGLTF::WriteGltfSceneToFile(const Model *model,
   }
 
   if (writeBinary) {
-    return WriteBinaryGltfFile(filename, detail::JsonToString(output), binBuffer);
+    return WriteBinaryGltfFile(filename, detail::JsonToString(output),
+                               binBuffer);
   } else {
-    return WriteGltfFile(filename, detail::JsonToString(output, (prettyPrint ? 2 : -1)));
+    return WriteGltfFile(filename,
+                         detail::JsonToString(output, (prettyPrint ? 2 : -1)));
   }
 }
 


### PR DESCRIPTION
This pull request modernizes the code a bit, replacing member initialization lists by default member initialization.
This is related to https://github.com/syoyo/tinygltf/commit/7a570c88d996918489bbbd3af7ebbda1f3f74a0a#r119070408

I used clang-tidy to refactor the code. The following [checks](https://clang.llvm.org/extra/clang-tidy/checks/list.html) were used:
- [modernize-use-default-member-init](https://github.com/syoyo/tinygltf/commit/a64f4b44420aebb9645536dc441254397b6520ca)
- [readability-redundant-string-init](https://github.com/syoyo/tinygltf/commit/c704d73bd0a0edf0b5075e954b07b9d7ca703d38)
- [modernize-use-equals-default](https://github.com/syoyo/tinygltf/commit/3e98ac45642f2d5d6fb646b25fe4ddd79b5d3bc4)
- [cppcoreguidelines-prefer-member-initializer](https://github.com/syoyo/tinygltf/commit/cb6a7070146a125e0e7fae759f34f8a2eebbf918)