### PR TITLE
Fix issue when serializing extensions of a primitive

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -7473,7 +7473,7 @@ static void SerializeGltfMesh(const Mesh &mesh, detail::json &o) {
       detail::JsonAddMember(primitive, "targets", std::move(targets));
     }
 
-    SerializeExtrasAndExtensions(gltfPrimitive, o);
+    SerializeExtrasAndExtensions(gltfPrimitive, primitive);
 
     detail::JsonPushBack(primitives, std::move(primitive));
   }


### PR DESCRIPTION
Hi,

It seems a small regression has been introduced during the refactor of extensions and extra serialization. 
Note that this bug was already fixed in #230.

Regards