### PR TITLE
Be tolerant when encountering emissiveFactor with array length 4

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -195,6 +195,11 @@ typedef enum {
   OBJECT_TYPE
 } Type;
 
+typedef enum {
+  PERMISSIVE,
+  STRICT
+} ParseStrictness;
+
 static inline int32_t GetComponentSizeInBytes(uint32_t componentType) {
   if (componentType == TINYGLTF_COMPONENT_TYPE_BYTE) {
     return 1;
@@ -1464,6 +1469,11 @@ class TinyGLTF {
                             bool prettyPrint, bool writeBinary);
 
   ///
+  /// Sets the parsing strictness.
+  ///
+  void SetParseStrictness(ParseStrictness strictness);
+
+  ///
   /// Set callback to use for loading image data
   ///
   void SetImageLoader(LoadImageDataFunction LoadImageData, void *user_data);
@@ -1551,6 +1561,8 @@ class TinyGLTF {
   const unsigned char *bin_data_ = nullptr;
   size_t bin_size_ = 0;
   bool is_binary_ = false;
+
+  ParseStrictness strictness_ = ParseStrictness::STRICT;
 
   bool serialize_default_values_ = false;  ///< Serialize default values?
 
@@ -2551,6 +2563,10 @@ static bool LoadExternalFile(std::vector<unsigned char> *out, std::string *err,
 
   out->swap(buf);
   return true;
+}
+
+void TinyGLTF::SetParseStrictness(ParseStrictness strictness) {
+  strictness_ = strictness;
 }
 
 void TinyGLTF::SetImageLoader(LoadImageDataFunction func, void *user_data) {
@@ -5194,13 +5210,14 @@ static bool ParsePbrMetallicRoughness(
 
 static bool ParseMaterial(Material *material, std::string *err, std::string *warn,
                           const detail::json &o,
-                          bool store_original_json_for_extras_and_extensions) {
+                          bool store_original_json_for_extras_and_extensions,
+                          ParseStrictness strictness) {
   ParseStringProperty(&material->name, err, o, "name", /* required */ false);
 
   if (ParseNumberArrayProperty(&material->emissiveFactor, err, o,
                                "emissiveFactor",
                                /* required */ false)) {
-    if (material->emissiveFactor.size() == 4) {
+    if (strictness==ParseStrictness::PERMISSIVE && material->emissiveFactor.size() == 4) {
       if (warn) {
         (*warn) +=
             "Array length of `emissiveFactor` parameter in "
@@ -6207,7 +6224,8 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
       ParseStringProperty(&material.name, err, o, "name", false);
 
       if (!ParseMaterial(&material, err, warn, o,
-                         store_original_json_for_extras_and_extensions_)) {
+                         store_original_json_for_extras_and_extensions_,
+                         strictness_)) {
         return false;
       }
 

--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -5192,7 +5192,7 @@ static bool ParsePbrMetallicRoughness(
   return true;
 }
 
-static bool ParseMaterial(Material *material, std::string *err,
+static bool ParseMaterial(Material *material, std::string *err, std::string *warn,
                           const detail::json &o,
                           bool store_original_json_for_extras_and_extensions) {
   ParseStringProperty(&material->name, err, o, "name", /* required */ false);
@@ -5200,7 +5200,15 @@ static bool ParseMaterial(Material *material, std::string *err,
   if (ParseNumberArrayProperty(&material->emissiveFactor, err, o,
                                "emissiveFactor",
                                /* required */ false)) {
-    if (material->emissiveFactor.size() != 3) {
+    if (material->emissiveFactor.size() == 4) {
+      if (warn) {
+        (*warn) +=
+            "Array length of `emissiveFactor` parameter in "
+            "material must be 3, but got 4\n";
+      }
+      material->emissiveFactor.resize(3);
+    }
+    else if (material->emissiveFactor.size() != 3) {
       if (err) {
         (*err) +=
             "Array length of `emissiveFactor` parameter in "
@@ -6198,7 +6206,7 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
       Material material;
       ParseStringProperty(&material.name, err, o, "name", false);
 
-      if (!ParseMaterial(&material, err, o,
+      if (!ParseMaterial(&material, err, warn, o,
                          store_original_json_for_extras_and_extensions_)) {
         return false;
       }


### PR DESCRIPTION
Raise a warning when encountering emissiveFactor with array length of 4 and truncate to the first 3 elements, instead of aborting the model loading entirely.