### PR TITLE
Fix Light reference in the node issue #458

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -7752,7 +7752,7 @@ static void SerializeGltfNode(const Node &node, detail::json &o) {
       detail::JsonSetObject(lights_punctual);
       detail::JsonAddMember(extensions, "KHR_lights_punctual",
                             std::move(lights_punctual));
-      detail::FindMember(o, "KHR_lights_punctual", it);
+      detail::FindMember(extensions, "KHR_lights_punctual", it);
     }
     SerializeNumberProperty("light", node.light, detail::GetValue(it));
   } else {


### PR DESCRIPTION
The bug is actually a crasher, if one has asserts enabled.

tiny_gltf.h - access correct json object when serializing a light, this fixes an assert and causes us to serialze the light index properly; tester.cc - add respective testcase