### PR TITLE
Fix Empty scenes are wrongly serialized as null Issue #464

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -8063,6 +8063,15 @@ static void SerializeGltfModel(const Model *model, detail::json &o) {
     for (unsigned int i = 0; i < model->scenes.size(); ++i) {
       detail::json currentScene;
       SerializeGltfScene(model->scenes[i], currentScene);
+      if (detail::JsonIsNull(currentScene)) {
+        // Issue 464.
+        // `scene` does not have any required parameters,
+        // so the result may be null(unmodified) when all scene parameters
+        // have default value.
+        //
+        // null is not allowed thus we create an empty JSON object.
+        detail::JsonSetObject(currentScene);
+      }
       detail::JsonPushBack(scenes, std::move(currentScene));
     }
     detail::JsonAddMember(o, "scenes", std::move(scenes));


### PR DESCRIPTION
tinygltf.h - serialize empty scenes as empty json objects;
tester.cc 
- add respective test case
- bring test cases in correct order
- tag test case for light index with correct issue number and fix it to compare to deserialized model