### PR TITLE
M_PI was not defined by <cmath>

### DIFF
--- a/examples/glview/glview.cc
+++ b/examples/glview/glview.cc
@@ -788,8 +788,10 @@ static void QuatToAngleAxis(const std::vector<double> quaternion,
     return;
   }
 
+  constexpr double pi = 3.14159265358979323846;
+
   double denom = sqrt(1-qw*qw);
-  outAngleDegrees = angleRadians * 180.0 / M_PI;
+  outAngleDegrees = angleRadians * 180.0 / pi;
   axis[0] = qx / denom;
   axis[1] = qy / denom;
   axis[2] = qz / denom;


### PR DESCRIPTION
`<cmath>` does not define `M_PI` on WIN32. Whilst we could define `_USE_MATH_DEFINES` in the project settings, or in code, it seems better to simply define a constant. It's only used at this one point, so makes sense to do it locally.