### PR TITLE
Fix C4018 warnings in MSVC on WIN32

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -3019,12 +3019,12 @@ bool GetFileSizeInBytes(size_t *filesize_out, std::string *err,
   }
 
   f.seekg(0, f.end);
-  size_t sz = static_cast<size_t>(f.tellg());
+  const auto sz = f.tellg();
 
   // std::cout << "sz = " << sz << "\n";
   f.seekg(0, f.beg);
 
-  if (int64_t(sz) < 0) {
+  if (sz < 0) {
     if (err) {
       (*err) += "Invalid file size : " + filepath +
                 " (does the path point to a directory?)";
@@ -3114,12 +3114,12 @@ bool ReadWholeFile(std::vector<unsigned char> *out, std::string *err,
   }
 
   f.seekg(0, f.end);
-  size_t sz = static_cast<size_t>(f.tellg());
+  const auto sz = f.tellg();
 
   // std::cout << "sz = " << sz << "\n";
   f.seekg(0, f.beg);
 
-  if (int64_t(sz) < 0) {
+  if (sz < 0) {
     if (err) {
       (*err) += "Invalid file size : " + filepath +
                 " (does the path point to a directory?)";

--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -3030,7 +3030,7 @@ bool GetFileSizeInBytes(size_t *filesize_out, std::string *err,
                 " (does the path point to a directory?)";
     }
     return false;
-  } else if (sz == 0) {
+  } else if (sz == std::streamoff(0)) {
     if (err) {
       (*err) += "File is empty : " + filepath + "\n";
     }
@@ -3125,7 +3125,7 @@ bool ReadWholeFile(std::vector<unsigned char> *out, std::string *err,
                 " (does the path point to a directory?)";
     }
     return false;
-  } else if (sz == 0) {
+  } else if (sz == std::streamoff(0)) {
     if (err) {
       (*err) += "File is empty : " + filepath + "\n";
     }


### PR DESCRIPTION
This fixes two C4018 (signed/unsigned mismatch) warnings in MSVC on WIN32 by using const auto, and removing some type casts.