### PR TITLE
Fix stripping of slashes from paths

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -2245,7 +2245,7 @@ static std::string GetFilePathExtension(const std::string &FileName) {
 
 static std::string GetBaseDir(const std::string &filepath) {
   if (filepath.find_last_of("/\\") != std::string::npos)
-    return filepath.substr(0, filepath.find_last_of("/\\"));
+    return filepath.substr(0, filepath.find_last_of("/\\") + 1);
   return "";
 }
 


### PR DESCRIPTION
## Context

Our team ran into issues where slashes were being stripped when a filepath with a protocol was supplied. For example, say `duck.gltf` references `ducktex.png`. If we supplied a URI like `file://duck.gltf` into tinygltf it would search for `file:/ducktex.png` (note the single slash).

This is because `GetBaseDir()` strips out the final slash. In most cases this is fine because `JoinPath()` adds the "/" back in. However, `JoinPath()` has the following check:
```
    if (lastChar != '/') {
      return path0 + std::string("/") + path1;
    } else {
      return path0 + path1;
    }
```

This means that for the "file://duck.gltf" case, `GetBaseDir("file://duck.gltf") = "file:/"`. And then `JoinPath("file:/", "ducktext.png") = "file:/ducktext.png"`.

The simple solution in this PR is to just leave the slash in when getting the base directory. I'm happy to modify `JoinPath` as well if you would like (I think we can remove the special if logic but wanted to keep this diff as simple as possible).

## Testing 
Ran tests using the test_runner:
```
tinygltf % python3 test_runner.py
Testing: /Users/pmcg/github/glTF-Sample-Models/2.0/AnimatedMorphCube/glTF/AnimatedMorphCube.gltf
Testing: /Users/pmcg/github/glTF-Sample-Models/2.0/AnimatedMorphCube/glTF-Binary/AnimatedMorphCube.glb
Testing: /Users/pmcg/github/glTF-Sample-Models/2.0/DamagedHelmet/glTF/DamagedHelmet.gltf
...
Success : 213
Failed  : 0
```