### PR TITLE
Properly clear the model before loading

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -6108,16 +6108,8 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
     }
   }
 
-  model->buffers.clear();
-  model->bufferViews.clear();
-  model->accessors.clear();
-  model->meshes.clear();
-  model->cameras.clear();
-  model->nodes.clear();
-  model->extensionsUsed.clear();
-  model->extensionsRequired.clear();
-  model->extensions.clear();
-  model->defaultScene = -1;
+  // Reset the model
+  (*model) = Model();
 
   // 1. Parse Asset
   {


### PR DESCRIPTION
Not all, but only some, model fields were cleared before parsing.
As one can pass an existing model to the load functions, we should make sure to completely wipe the model before parsing.