### PR TITLE
Add ability to disable image loading

### DIFF
--- a/tests/tester.cc
+++ b/tests/tester.cc
@@ -1200,3 +1200,32 @@ TEST_CASE("inverse-bind-matrices-optional", "[issue-492]") {
   REQUIRE(true == ret);
   REQUIRE(err.empty());
 }
+
+TEST_CASE("external-images") {
+    std::string err;
+    std::string warn;
+    tinygltf::Model model;
+    tinygltf::TinyGLTF ctx;
+    ctx.SetLoadImages(false);
+
+    const std::string basePath = "../models/Cube/";
+    bool ok = ctx.LoadASCIIFromFile(&model, &err, &warn, basePath + "Cube.gltf");
+    REQUIRE(ok);
+    REQUIRE(err.empty());
+    REQUIRE(warn.empty());
+
+    for (const auto& image : model.images) {
+      CHECK(image.image.empty());
+      std::fstream file(basePath + image.uri);
+      CHECK(file.good());
+    }
+
+    ok = ctx.WriteGltfSceneToFile(&model, "Cube.gltf");
+    REQUIRE(ok);
+
+    // External images should be found in basedir of written model
+    for (const auto& image : model.images) {
+      std::fstream file(image.uri);
+      CHECK(file.good());
+    }
+}


### PR DESCRIPTION
Hi. This is a PR which allows to completely disable image loading. This is important if one has glTF models with gigabytes of external images, or a huge GLB where most of the data is images.

Image saving is still correctly handled, by looking for the source model's image files, and copying them over to the directory where the target glTF is written.