### PR TITLE
Fix Animation extensions being loaded in place of Sampler extensions

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -5597,7 +5597,7 @@ static bool ParseAnimation(Animation *animation, std::string *err,
         }
         sampler.input = inputIndex;
         sampler.output = outputIndex;
-        ParseExtrasAndExtensions(&sampler, err, o,
+        ParseExtrasAndExtensions(&sampler, err, s,
                                  store_original_json_for_extras_and_extensions);
 
         animation->samplers.emplace_back(std::move(sampler));


### PR DESCRIPTION
The title says it all.
Currently, Animation Sampler extensions are not loaded and Animation extensions are loaded to their member instead.