### PR TITLE
CMake: allow opt-out of installing vendored headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ option(TINYGLTF_BUILD_VALIDATOR_EXAMPLE "Build validator exampe" OFF)
 option(TINYGLTF_BUILD_BUILDER_EXAMPLE "Build glTF builder example" OFF)
 option(TINYGLTF_HEADER_ONLY "On: header-only mode. Off: create tinygltf library(No TINYGLTF_IMPLEMENTATION required in your project)" OFF)
 option(TINYGLTF_INSTALL "Install tinygltf files during install step. Usually set to OFF if you include tinygltf through add_subdirectory()" ON)
+option(TINYGLTF_INSTALL_VENDOR "Install vendored nlohmann/json and nothings/stb headers" ON)
 
 if (TINYGLTF_BUILD_LOADER_EXAMPLE)
   add_executable(loader_example
@@ -67,13 +68,20 @@ if (TINYGLTF_INSTALL)
   # Do not install .lib even if !TINYGLTF_HEADER_ONLY
 
   INSTALL ( FILES
-    json.hpp
-    stb_image.h
-    stb_image_write.h
     tiny_gltf.h
     ${TINYGLTF_EXTRA_SOUECES}
     DESTINATION
     include
     )
+
+    if(TINYGLTF_INSTALL_VENDOR)
+      INSTALL ( FILES
+        json.hpp
+        stb_image.h
+        stb_image_write.h
+        DESTINATION
+        include
+        )
+    endif()
 
 endif(TINYGLTF_INSTALL)


### PR DESCRIPTION
Hi,

I already have nlohmann/json & nothings/stb on my system, and would like to be able to install tinygltf without conflicts.

Here is a simple fix for that.