### PR TITLE
Add bounds check to images loaded from bufferviews

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -6453,6 +6453,15 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
           return false;
         }
         const Buffer &buffer = model->buffers[size_t(bufferView.buffer)];
+        if (bufferView.byteOffset >= buffer.data.size()) {
+          if (err) {
+            std::stringstream ss;
+            ss << "image[" << idx << "] bufferView \"" << image.bufferView
+               << "\" indexed out of bounds of its buffer." << std::endl;
+            (*err) += ss.str();
+          }
+          return false;
+        }
 
         if (LoadImageData == nullptr) {
           if (err) {


### PR DESCRIPTION
**Describe the issue**

glTF binary files containing embedded images can read outside of bounds of their bufferview and lead to a SIGSEGV/general memory read out of bounds; discovered with AFL++.

**To Reproduce**

 Load the GLB from [carbonFibre.zip](https://github.com/user-attachments/files/18484946/carbonFibre.zip) to a `tinygltf::TinyGLTF::LoadBinaryFromMemory` call and have ASAN on. The callstack is a bit misleading since it's downstream of what is actually introducing the issue:
 
 ```
    #0 0x419622 in stbi__get8 stb_image_1_30.h:1617
    #1 0x423885 in stbi__get_marker stb_image_1_30.h:2923
    #2 0x4333d1 in stbi__decode_jpeg_header stb_image_1_30.h:3371
    #3 0x451e36 in stbi__jpeg_info_raw stb_image_1_30.h:4058
    #4 0x451e36 in stbi__jpeg_info stb_image_1_30.h:4075
    #5 0x451e36 in stbi__info_main stb_image_1_30.h:7635
    #6 0x456176 in stbi_info_from_memory stb_image_1_30.h:7738
    #7 0x46f2ad in tinygltf::LoadImageData(tinygltf::Image*, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, int, int, unsigned char const*, int, void*) tiny_gltf.h:2630
    #8 0x4ec3d0 in std::function<bool (tinygltf::Image*, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, int, int, unsigned char const*, int, void*)>::operator()(tinygltf::Image*, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, int, int, unsigned char const*, int, void*) const /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/include/c++/14-20241116/bits/std_function.h:591
    #9 0x4ec3d0 in operator() tiny_gltf.h:6463
    #10 0x4ef785 in ForEachInArray<tinygltf::TinyGLTF::LoadFromString(tinygltf::Model*, std::string*, std::string*, char const*, unsigned int, const std::string&, unsigned int)::<lambda(const nlohmann::json&)> > tiny_gltf.h:5981
    #11 0x4f2c9b in tinygltf::TinyGLTF::LoadFromString(tinygltf::Model*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, char const*, unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsigned int) tiny_gltf.h:6417
    #12 0x500a59 in tinygltf::TinyGLTF::LoadBinaryFromMemory(tinygltf::Model*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, unsigned char const*, unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsigned int) tiny_gltf.h:6918
 ```
 
 
 **With patch**
 
 Instead of a SIGSEGV, the read is caught and the `err` parameter is filled out (in this testcase) with `image[0] bufferView "3" indexed out of bounds of its buffer.` noting what went wrong.