### PR TITLE
Initialize Accessor::Sparse members to default values

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -834,20 +834,20 @@ struct Accessor {
       maxValues;  // optional. integer value is promoted to double
 
   struct Sparse {
-    int count;
-    bool isSparse;
+    int count{0};
+    bool isSparse{false};
     struct {
-      size_t byteOffset;
-      int bufferView;
-      int componentType;  // a TINYGLTF_COMPONENT_TYPE_ value
+      size_t byteOffset{0};
+      int bufferView{-1};
+      int componentType{-1};  // a TINYGLTF_COMPONENT_TYPE_ value
       Value extras;
       ExtensionMap extensions;
       std::string extras_json_string;
       std::string extensions_json_string;
     } indices;
     struct {
-      int bufferView;
-      size_t byteOffset;
+      int bufferView{-1};
+      size_t byteOffset{0};
       Value extras;
       ExtensionMap extensions;
       std::string extras_json_string;
@@ -898,11 +898,7 @@ struct Accessor {
     // unreachable return 0;
   }
 
-  Accessor()
-
-  {
-    sparse.isSparse = false;
-  }
+  Accessor() = default;
   DEFAULT_METHODS(Accessor)
   bool operator==(const tinygltf::Accessor &) const;
 };

--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -898,6 +898,7 @@ struct Accessor {
     // unreachable return 0;
   }
 
+  Accessor() = default;
   DEFAULT_METHODS(Accessor)
   bool operator==(const tinygltf::Accessor &) const;
 };

--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -898,7 +898,6 @@ struct Accessor {
     // unreachable return 0;
   }
 
-  Accessor() = default;
   DEFAULT_METHODS(Accessor)
   bool operator==(const tinygltf::Accessor &) const;
 };


### PR DESCRIPTION
**Describe the issue**

When including "tiny_gltf.h" into a new project in Visual Studio 2022, linter emits [C26495](https://learn.microsoft.com/en-us/cpp/code-quality/c26495?view=msvc-170) warning about uninitialized member variables in Accessor::Sparse. I confirmed with debugger that an unused Accessor::Sparse is filled with garbage upon initialization.

**With patch**

Set default values for Accessor::Sparse members following convention of other classes. Set Accessor constructor to default as it is not needed anymore. 