### PR TITLE
Removed TINYGLTF_USE_CPP14 option since it is unused

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,6 @@ if (!ret) {
 * `TINYGLTF_NO_INCLUDE_STB_IMAGE `: Disable including `stb_image.h` from within `tiny_gltf.h` because it has been already included before or you want to include it using custom path before including `tiny_gltf.h`.
 * `TINYGLTF_NO_INCLUDE_STB_IMAGE_WRITE `: Disable including `stb_image_write.h` from within `tiny_gltf.h` because it has been already included before or you want to include it using custom path before including `tiny_gltf.h`.
 * `TINYGLTF_USE_RAPIDJSON` : Use RapidJSON as a JSON parser/serializer. RapidJSON files are not included in TinyGLTF repo. Please set an include path to RapidJSON if you enable this feature.
-* `TINYGLTF_USE_CPP14` : Use C++14 feature(requires C++14 compiler). This may give better performance than C++11.
 
 
 ## CMake options

--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -50,12 +50,6 @@
 #include <utility>
 #include <vector>
 
-// Auto-detect C++14 standard version
-#if !defined(TINYGLTF_USE_CPP14) && defined(__cplusplus) && \
-    (__cplusplus >= 201402L)
-#define TINYGLTF_USE_CPP14
-#endif
-
 #ifdef __ANDROID__
 #ifdef TINYGLTF_ANDROID_LOAD_FROM_ASSETS
 #include <android/asset_manager.h>


### PR DESCRIPTION
Hello,

Whilst browsing some compile options I wanted to use, I noticed this define is completely unused. Very trivial but thought I'd point it out. The define isn't used anywhere in the library to do something c++14 specific, whereas it did in the past (#201).

Kind regards,
Niels