### PR TITLE
Bump minimum required version to 3.10.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.10)
 
 project(tinygltf)
 


### PR DESCRIPTION
Bump minimum required version to 3.10.0.

After updating CMake on my system I was getting annoyed by warning that support for CMake < 3.10 will be removed in future version.