### PR TITLE
Fixed minor syntax issue in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,27 +153,29 @@ Copy `stb_image.h`, `stb_image_write.h`, `json.hpp` and `tiny_gltf.h` to your pr
 // #define TINYGLTF_NOEXCEPTION // optional. disable exception handling.
 #include "tiny_gltf.h"
 
-using namespace tinygltf;
+int main(int /* argc */, char *argv[]){
+  using namespace tinygltf;
 
-Model model;
-TinyGLTF loader;
-std::string err;
-std::string warn;
+  Model model;
+  TinyGLTF loader;
+  std::string err;
+  std::string warn;
 
-bool ret = loader.LoadASCIIFromFile(&model, &err, &warn, argv[1]);
-//bool ret = loader.LoadBinaryFromFile(&model, &err, &warn, argv[1]); // for binary glTF(.glb)
+  bool ret = loader.LoadASCIIFromFile(&model, &err, &warn, argv[1]);
+  // bool ret = loader.LoadBinaryFromFile(&model, &err, &warn, argv[1]); // for binary glTF(.glb)
 
-if (!warn.empty()) {
-  printf("Warn: %s\n", warn.c_str());
-}
+  if (!warn.empty()) {
+    printf("Warn: %s\n", warn.c_str());
+  }
 
-if (!err.empty()) {
-  printf("Err: %s\n", err.c_str());
-}
+  if (!err.empty()) {
+    printf("Err: %s\n", err.c_str());
+  }
 
-if (!ret) {
-  printf("Failed to parse glTF\n");
-  return -1;
+  if (!ret) {
+    printf("Failed to parse glTF\n");
+    return -1;
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ int main(int /* argc */, char *argv[]){
     printf("Failed to parse glTF\n");
     return -1;
   }
+
+  return 0;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Copy `stb_image.h`, `stb_image_write.h`, `json.hpp` and `tiny_gltf.h` to your pr
 // #define TINYGLTF_NOEXCEPTION // optional. disable exception handling.
 #include "tiny_gltf.h"
 
-int main(int /* argc */, char *argv[]){
+int main(int /* argc */, char *argv[]) {
   using namespace tinygltf;
 
   Model model;


### PR DESCRIPTION
The original README example contained a small syntax/usage error that could confuse users attempting to compile the sample code directly.

This update improves the reliability of the documentation.
