### PR TITLE
Removing problematic using namespace in a header file

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -2451,9 +2451,8 @@ inline unsigned char from_hex(unsigned char ch) {
 }
 
 static const std::string urldecode(const std::string &str) {
-  using namespace std;
-  string result;
-  string::size_type i;
+  std::string result;
+  std::string::size_type i;
   for (i = 0; i < str.size(); ++i) {
     if (str[i] == '+') {
       result += ' ';


### PR DESCRIPTION
Remove `using namespace std` from public header

Removing the `using namespace std` directive from the public header to avoid polluting the global namespace of any consuming project. This is a breaking change for downstream consumers who may have been relying on implicit `std` symbol resolution — they will need to explicitly qualify any affected `std::` types or add their own `using` declarations in their own translation units.