### PR TITLE
Handle invalid UTF-8 in JSON serialization instead of throwing

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -3664,7 +3664,7 @@ std::string JsonToString(const detail::json &o, int spacing = -1) {
   }
   return buffer.GetString();
 #else
-  return o.dump(spacing);
+  return o.dump(spacing, ' ', false, detail::json::error_handler_t::replace);
 #endif
 }
 


### PR DESCRIPTION
WriteGltfSceneToStream crashes with an unhandled type_error when the model contains strings with invalid UTF-8 bytes (e.g. from partially URL-decoded URIs like "%Er" which produces 0xE0, an incomplete multi-byte sequence).

Use nlohmann/json's error_handler_t::replace mode in dump() so invalid bytes are replaced with U+FFFD instead of throwing.