### PR TITLE
Fix SEGV in tg3_model_free after tg3_parse_glb failure

### DIFF
--- a/tiny_gltf_v3.h
+++ b/tiny_gltf_v3.h
@@ -3394,6 +3394,8 @@ TINYGLTF3_API tg3_error_code tg3_parse_glb(
     const char *base_dir, uint32_t base_dir_len,
     const tg3_parse_options *options) {
 
+    tg3__model_init(model);
+
     const uint8_t *json_chunk = NULL;
     uint64_t json_chunk_size = 0;
     const uint8_t *bin_chunk = NULL;
@@ -3410,8 +3412,6 @@ TINYGLTF3_API tg3_error_code tg3_parse_glb(
         tg3_parse_options_init(&default_opts);
         options = &default_opts;
     }
-
-    tg3__model_init(model);
 
     tg3_arena *arena = tg3__arena_create(&options->memory);
     if (!arena) {


### PR DESCRIPTION
tg3_parse_glb called tg3__model_init after the GLB header check, so an early return on invalid headers left the model struct uninitialized. A subsequent tg3_model_free would then dereference garbage in model->arena_, causing a segfault.

Move tg3__model_init to the top of tg3_parse_glb so that model->arena_ is always NULL on parse failure, matching the behavior of tg3_parse.