### PR TITLE
Fix crash in ParseBuffer when byteLength is zero

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -4614,8 +4614,10 @@ static bool ParseBuffer(Buffer *buffer, std::string *err, const detail::json &o,
       }
 
       // Read buffer data
-      buffer->data.resize(static_cast<size_t>(byteLength));
-      memcpy(&(buffer->data.at(0)), bin_data, static_cast<size_t>(byteLength));
+      if (byteLength > 0) {
+        buffer->data.resize(static_cast<size_t>(byteLength));
+        memcpy(buffer->data.data(), bin_data, static_cast<size_t>(byteLength));
+      }
     }
 
   } else {


### PR DESCRIPTION
The glTF spec requires buffer.byteLength >= 1, so zero-length buffers are spec-invalid. However, when loading a malformed GLB with byteLength=0, the library should fail gracefully instead of crashing with std::out_of_range from vector::at(0).

Wrap the resize+memcpy in a byteLength > 0 guard and use .data() instead of .at(0).