### PR TITLE
Add code to adapt to the HarmonyOS platform

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -56,6 +56,10 @@
 #endif
 #endif
 
+#ifdef __OHOS__
+#include <rawfile/raw_file_manager.h>
+#endif
+
 #ifdef __GNUC__
 #if (__GNUC__ < 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ <= 8))
 #define TINYGLTF_NOEXCEPT
@@ -178,6 +182,10 @@ AAssetManager *asset_manager = nullptr;
 extern AAssetManager *asset_manager;
 #endif
 #endif
+#endif
+
+#ifdef __OHOS__
+NativeResourceManager *rawfile_manager = nullptr;
 #endif
 
 typedef enum {
@@ -1789,7 +1797,7 @@ class TinyGLTF {
 
 #endif
 
-#elif !defined(__ANDROID__) && !defined(__OpenBSD__)
+#elif !defined(__ANDROID__) && !defined(__OpenBSD__) && !defined(__OHOS__)
 // #include <wordexp.h>
 #endif
 
@@ -2921,6 +2929,18 @@ bool FileExists(const std::string &abs_filename, void *) {
     return false;
   }
 #else
+#ifdef __OHOS__
+  if (rawfile_manager) {
+    RawFile* asset = OH_ResourceManager_OpenRawFile(rawfile_manager, abs_filename.c_str());
+    if (!asset) {
+      return false;
+    }
+    OH_ResourceManager_CloseRawFile(asset);
+    ret = true;
+  } else {
+    return false;
+  }
+#endif
 #ifdef _WIN32
 #if defined(_MSC_VER) || defined(_LIBCPP_VERSION)
 
@@ -3001,7 +3021,8 @@ std::string ExpandFilePath(const std::string &filepath, void *) {
 #else
 
 #if defined(TARGET_OS_IPHONE) || defined(TARGET_IPHONE_SIMULATOR) || \
-    defined(__ANDROID__) || defined(__EMSCRIPTEN__) || defined(__OpenBSD__)
+    defined(__ANDROID__) || defined(__EMSCRIPTEN__) || defined(__OpenBSD__) \
+    || defined(__OHOS__)
   // no expansion
   std::string s = filepath;
 #else
@@ -3061,6 +3082,31 @@ bool GetFileSizeInBytes(size_t *filesize_out, std::string *err,
       return false;
     }
 
+    return true;
+  } else {
+    if (err) {
+      (*err) += "No asset manager specified : " + filepath + "\n";
+    }
+    return false;
+  }
+#else
+#ifdef __OHOS__
+  if (rawfile_manager) {
+    RawFile* rawfile = OH_ResourceManager_OpenRawFile(rawfile_manager,
+                                      filepath.c_str());
+    if (!rawfile) {
+      if (err) {
+        (*err) += "File open error : " + filepath + "\n";
+      }
+      return false;
+    }
+    size_t size = OH_ResourceManager_GetRawFileSize(rawfile);
+    if (size <= 0) {
+      if (err) {
+        (*err) += "Invalid file size : " + filepath +
+                " (does the path point to a directory?)";
+      }
+    }
     return true;
   } else {
     if (err) {
@@ -3163,6 +3209,30 @@ bool ReadWholeFile(std::vector<unsigned char> *out, std::string *err,
     }
     return false;
   }
+#else
+#ifdef __OHOS__
+  if (rawfile_manager) {
+    RawFile* rawfile = OH_ResourceManager_OpenRawFile(rawfile_manager,
+                                          filepath.c_str());
+    if (!rawfile) {
+      if (err) {
+        (*err) += "File open error : " + filepath + "\n";
+      }
+      return false;
+    }
+    size_t size = OH_ResourceManager_GetRawFileSize(rawfile);
+    if (size <= 0) {
+      if (err) {
+        (*err) += "Invalid file size : " + filepath +
+                  " (does the path point to a directory?)";
+      }
+      return false;
+    }
+    out->resize(size);
+    OH_ResourceManager_ReadRawFile(rawfile,
+      reinterpret_cast<char *>(&out->at(0)), size);
+    OH_ResourceManager_CloseRawFile(rawfile);
+    return true;
 #else
 #ifdef _WIN32
 #if defined(__GLIBCXX__)  // mingw


### PR DESCRIPTION
## Description

This PR adds support for the **OpenHarmony platform** in tinygltf.

On OpenHarmony, the standard file I/O APIs (e.g., `fopen`, `std::ifstream`) cannot directly access assets bundled inside a HAP package. This change introduces an alternative file read/write path using OpenHarmony's **NativeResourceManager** API, which is the official way to access raw assets on this platform.

All changes are guarded by the `__OHOS__` macro, so there is **no impact on any existing platform** (Windows, Linux, Android, macOS, etc.).

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
### Required for All PRs
- [ ] Reproducible glTF test file(s) are included (e.g., `models/regression/`, `tests/issue-***.gltf`, etc.)
- [ ] Unit tests are written and pass locally (`cd tests && ./tester`)

### Required for Feature PRs
- [ ] Specification document is included (e.g., `docs/spec/<feature-name>.md`)

> Note: This change is a platform-specific I/O adaptation rather than a glTF feature extension, so a spec document and new glTF test files are not applicable. The existing test suite passes unchanged on all other platforms.

## Test Instructions

Testing requires a real OpenHarmony / HarmonyOS Next device and DevEco Studio:

1. Open the project in **DevEco Studio**
2. Build and deploy to a physical device running HarmonyOS Next (API 12–22)
3. Verify that glTF models are loaded correctly via `NativeResourceManager`

For all other platforms, the existing test suite can be used as normal:
```
cd tests && ./tester
```

## Related Issues

Related to: SaschaWillems/Vulkan#1270 (HarmonyOS platform support for Vulkan examples)

## Additional Notes

- OpenHarmony bundles assets inside a `.hap` package; standard POSIX file APIs cannot read them directly
- `NativeResourceManager` is the official OpenHarmony API for raw asset access, equivalent to Android's `AAssetManager`
- All new code is isolated under `#ifdef __OHOS__` to ensure zero impact on existing builds