### PR TITLE
Fix ambiguous tinygltf_json constructor for unsigned int on 32-bit

### DIFF
--- a/tinygltf_json.h
+++ b/tinygltf_json.h
@@ -789,6 +789,7 @@ public:
     tinygltf_json(std::nullptr_t);
     tinygltf_json(bool b);
     tinygltf_json(int i);
+    tinygltf_json(unsigned int u);
     tinygltf_json(int64_t i);
     tinygltf_json(uint64_t u);
     tinygltf_json(double d);
@@ -1151,12 +1152,13 @@ inline void tinygltf_json::make_array_() {
 }
 
 /* Constructors */
-inline tinygltf_json::tinygltf_json()           { init_null_(); }
+inline tinygltf_json::tinygltf_json()               { init_null_(); }
 inline tinygltf_json::tinygltf_json(std::nullptr_t) { init_null_(); }
-inline tinygltf_json::tinygltf_json(bool b)     { init_null_(); type_ = CJ_BOOL; b_ = b ? 1 : 0; }
-inline tinygltf_json::tinygltf_json(int i)      { init_null_(); type_ = CJ_INT;  i_ = (int64_t)i; }
-inline tinygltf_json::tinygltf_json(int64_t i)  { init_null_(); type_ = CJ_INT;  i_ = i; }
-inline tinygltf_json::tinygltf_json(uint64_t u) {
+inline tinygltf_json::tinygltf_json(bool b)         { init_null_(); type_ = CJ_BOOL; b_ = b ? 1 : 0; }
+inline tinygltf_json::tinygltf_json(int i)          { init_null_(); type_ = CJ_INT;  i_ = (int64_t)i; }
+inline tinygltf_json::tinygltf_json(unsigned int u) { init_null_(); type_ = CJ_INT;  i_ = (int64_t)u; }
+inline tinygltf_json::tinygltf_json(int64_t i)      { init_null_(); type_ = CJ_INT;  i_ = i; }
+inline tinygltf_json::tinygltf_json(uint64_t u)     {
     init_null_();
     if (u <= (uint64_t)INT64_MAX) {
         type_ = CJ_INT;


### PR DESCRIPTION
On 32-bit platforms (e.g. i686), size_t is unsigned int rather than uint64_t. SerializeNumberProperty<size_t> therefore instantiates detail::json(unsigned int&), which is ambiguous among the int, int64_t, uint64_t, double, and float constructors -- none is an exact match, and the implicit conversions are equally ranked.

Add an explicit unsigned int constructor to tinygltf_json so the call resolves unambiguously on all target widths.

Fixes build on i686 / other 32-bit targets.

## Description

What does this PR do? Provide a brief summary of the changes. 

## Type of Change

- [x] Bug fix

## Checklist

### Required for All PRs

- [ ] Reproducible glTF test file(s) are included (e.g., `models/regression/`, `tests/issue-***.gltf`, etc.)
- [ ] Unit tests are written and pass locally (`cd tests && ./tester`)

### Security Policy

This project manages CVE assignments exclusively through GitHub Security Advisories.
PRs that include or reference independently obtained CVE IDs or external vulnerability disclosures will be closed.

## Test Instructions

How can reviewers verify your changes? 

Build against a 32bit target.
